### PR TITLE
correct the variable user_prompt_template

### DIFF
--- a/src/content_core/content/summary/core.py
+++ b/src/content_core/content/summary/core.py
@@ -8,7 +8,7 @@ async def summarize(content: str, context: str) -> str:
     templated_message_fn = partial(templated_message, model=ModelFactory.get_model('summary_model'))
     response = await templated_message_fn(
         TemplatedMessageInput(
-            user_prompt_template="content/summarize",
+            user_prompt_template="prompts/content/summarize",
             data={"content": content, "context": context},
         )
     )


### PR DESCRIPTION
**Reference Issues/PRs**
None.

**What does this implement/fix? Explain your changes.**
This PR fixes the incorrect reference to the `user_prompt_template` variable in `summary/core.py`.
The path was corrected to ensure the `summarize.jinja` template is properly located and loaded during execution.

**Any other comments?**
Tested with the `csum` command after correcting the template path.
Error related to missing template was resolved successfully.


