### PR TITLE
feat: add self-hosted Firecrawl API URL configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-01-25
+
+### Added
+- **Self-Hosted Firecrawl Support** - Configure a custom Firecrawl API URL for self-hosted instances
+  - Environment variable: `FIRECRAWL_API_BASE_URL`
+  - YAML config: `extraction.firecrawl.api_url`
+  - Programmatic API: `set_firecrawl_api_url()`, `get_firecrawl_api_url()`
+  - Debug logging when using a custom base URL
+  - Documentation with link to [Firecrawl self-hosting guide](https://github.com/mendableai/firecrawl/blob/main/SELF_HOST.md)
+
 ## [1.10.0] - 2026-01-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -488,6 +488,8 @@ In your `cc_config.yaml` or custom config, set:
 extraction:
   document_engine: docling  # 'auto' (default), 'simple', or 'docling'
   url_engine: auto          # 'auto' (default), 'simple', 'firecrawl', or 'jina'
+  firecrawl:
+    api_url: null           # Custom API URL for self-hosted Firecrawl
   docling:
     output_format: markdown  # markdown | html | json
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -289,7 +289,7 @@ export GOOGLE_API_KEY="your-google-key"
 
 **Getting API Keys:**
 - **OpenAI**: Visit [OpenAI API Keys](https://platform.openai.com/api-keys)
-- **Firecrawl**: Visit [Firecrawl](https://www.firecrawl.dev/) for enhanced web scraping
+- **Firecrawl**: Visit [Firecrawl](https://www.firecrawl.dev/) for enhanced web scraping, or [self-host your own instance](https://github.com/mendableai/firecrawl/blob/main/SELF_HOST.md)
 - **Jina**: Visit [Jina AI](https://jina.ai/) for alternative web extraction
 
 ### Engine Selection via Environment Variables
@@ -303,6 +303,7 @@ For advanced users, you can override the extraction engines:
       "env": {
         "OPENAI_API_KEY": "sk-...",
         "FIRECRAWL_API_KEY": "fc-...",
+        "FIRECRAWL_API_BASE_URL": "http://localhost:3002",  // For self-hosted Firecrawl
         "CCORE_DOCUMENT_ENGINE": "simple",    // Skip docling, use PyMuPDF
         "CCORE_URL_ENGINE": "auto"       // Or firecrawl, jina
       }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,6 +24,7 @@ Content Core supports environment variable overrides for extraction engines, use
 
 - **`CCORE_DOCUMENT_ENGINE`**: Override document engine (`auto`, `simple`, `docling`)
 - **`CCORE_URL_ENGINE`**: Override URL engine (`auto`, `simple`, `firecrawl`, `jina`, `crawl4ai`)
+- **`FIRECRAWL_API_BASE_URL`**: Custom Firecrawl API URL for self-hosted instances (default: `https://api.firecrawl.dev`)
 
 These environment variables take precedence over configuration file settings and per-call overrides.
 
@@ -109,6 +110,8 @@ Add under the `extraction` section:
 extraction:
   document_engine: docling  # auto (default), simple, or docling
   url_engine: auto          # auto (default), simple, firecrawl, jina, or crawl4ai
+  firecrawl:
+    api_url: null           # Custom API URL for self-hosted Firecrawl (e.g., "http://localhost:3002")
   docling:
     output_format: html     # markdown | html | json
   pymupdf:
@@ -133,10 +136,44 @@ set_url_engine("firecrawl")
 # pick format
 set_docling_output_format("json")
 
+# Use a self-hosted Firecrawl instance
+from content_core.config import set_firecrawl_api_url
+set_firecrawl_api_url("http://localhost:3002")
+
 # Configure PyMuPDF OCR for scientific documents
 set_pymupdf_ocr_enabled(True)
 set_pymupdf_formula_threshold(2)  # Lower threshold for math-heavy docs
 ```
+
+#### Self-Hosted Firecrawl
+
+Content Core supports self-hosted Firecrawl instances for users who want to run their own web scraping infrastructure. This is useful for privacy, compliance, or high-volume scraping needs.
+
+To use a self-hosted Firecrawl instance:
+
+1. **Set up Firecrawl** - Follow the [official self-hosting guide](https://github.com/mendableai/firecrawl/blob/main/SELF_HOST.md) to deploy Firecrawl using Docker Compose or Kubernetes.
+
+2. **Configure Content Core** - Point to your instance using one of these methods:
+
+   ```bash
+   # Environment variable
+   export FIRECRAWL_API_BASE_URL="http://localhost:3002"
+   ```
+
+   ```yaml
+   # YAML config (cc_config.yaml)
+   extraction:
+     firecrawl:
+       api_url: "http://localhost:3002"
+   ```
+
+   ```python
+   # Programmatic
+   from content_core.config import set_firecrawl_api_url
+   set_firecrawl_api_url("http://localhost:3002")
+   ```
+
+3. **Optional: Set API key** - If your self-hosted instance uses authentication, also set `FIRECRAWL_API_KEY`.
 
 #### Crawl4AI Engine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-core"
-version = "1.10.0"
+version = "1.11.0"
 description = "Extract what matters from any media source. Available as Python Library, macOS Service, CLI and MCP Server"
 readme = "README.md"
 homepage = "https://github.com/lfnovo/content-core"

--- a/src/content_core/cc_config.yaml
+++ b/src/content_core/cc_config.yaml
@@ -38,6 +38,9 @@ extraction:
   url_engine: auto  # auto | simple | firecrawl | jina | crawl4ai | docling - for URLs
   audio:
     concurrency: 3              # Number of concurrent audio transcriptions (1-10)
+  firecrawl:
+    api_url: null  # Custom API URL for self-hosted Firecrawl (e.g., "http://localhost:3002")
+                   # Environment variable FIRECRAWL_API_BASE_URL takes precedence
   docling:
     output_format: markdown  # markdown | html | json
   pymupdf:

--- a/src/content_core/config.py
+++ b/src/content_core/config.py
@@ -289,6 +289,62 @@ def set_audio_concurrency(concurrency: int):
     audio_cfg["concurrency"] = concurrency
 
 
+# Default Firecrawl API URL
+DEFAULT_FIRECRAWL_API_URL = "https://api.firecrawl.dev"
+
+
+def get_firecrawl_api_url() -> str:
+    """
+    Get the Firecrawl API URL with environment variable override.
+
+    Configuration priority (highest to lowest):
+    1. Environment variable FIRECRAWL_API_BASE_URL
+    2. YAML config (extraction.firecrawl.api_url)
+    3. Default: https://api.firecrawl.dev
+
+    Returns:
+        str: The Firecrawl API URL to use
+
+    Examples:
+        >>> import os
+        >>> os.environ["FIRECRAWL_API_BASE_URL"] = "http://localhost:3002"
+        >>> get_firecrawl_api_url()
+        'http://localhost:3002'
+    """
+    # 1. Environment variable (highest priority)
+    env_url = os.environ.get("FIRECRAWL_API_BASE_URL")
+    if env_url:
+        return env_url
+
+    # 2. YAML config
+    yaml_url = CONFIG.get("extraction", {}).get("firecrawl", {}).get("api_url")
+    if yaml_url:
+        return yaml_url
+
+    # 3. Default
+    return DEFAULT_FIRECRAWL_API_URL
+
+
+def set_firecrawl_api_url(api_url: str) -> None:
+    """
+    Override the Firecrawl API URL programmatically.
+
+    This sets the URL in the config, which takes precedence over the default
+    but can still be overridden by the FIRECRAWL_API_BASE_URL environment variable.
+
+    Args:
+        api_url: The Firecrawl API URL (e.g., 'http://localhost:3002')
+
+    Examples:
+        >>> set_firecrawl_api_url("http://localhost:3002")
+        >>> get_firecrawl_api_url()  # Returns 'http://localhost:3002' (unless env var is set)
+        'http://localhost:3002'
+    """
+    extraction = CONFIG.setdefault("extraction", {})
+    firecrawl_cfg = extraction.setdefault("firecrawl", {})
+    firecrawl_cfg["api_url"] = api_url
+
+
 def get_retry_config(operation_type: str) -> dict:
     """
     Get retry configuration for a specific operation type.

--- a/src/content_core/processors/url.py
+++ b/src/content_core/processors/url.py
@@ -6,7 +6,12 @@ from readability import Document
 
 from content_core.common import ProcessSourceState
 from content_core.common.retry import retry_url_api, retry_url_network
-from content_core.config import get_proxy, get_url_engine
+from content_core.config import (
+    DEFAULT_FIRECRAWL_API_URL,
+    get_firecrawl_api_url,
+    get_proxy,
+    get_url_engine,
+)
 from content_core.logging import logger
 from content_core.processors.docling import DOCLING_SUPPORTED
 from content_core.processors.office import SUPPORTED_OFFICE_TYPES
@@ -193,7 +198,15 @@ async def _fetch_url_firecrawl(url: str, proxy: str | None = None) -> dict:
             "Proxy will NOT be used for this request. Configure proxy on Firecrawl server instead."
         )
 
-    app = AsyncFirecrawlApp(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+    # Get custom API URL for self-hosted instances
+    api_url = get_firecrawl_api_url()
+    if api_url != DEFAULT_FIRECRAWL_API_URL:
+        logger.debug(f"Using custom Firecrawl API URL: {api_url}")
+
+    app = AsyncFirecrawlApp(
+        api_key=os.environ.get("FIRECRAWL_API_KEY"),
+        api_url=api_url,
+    )
     scrape_result = await app.scrape(url, formats=["markdown", "html"])
     return {
         "title": scrape_result.metadata.title or "",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,8 +3,12 @@ from unittest.mock import patch
 from content_core.config import (
     get_document_engine,
     get_url_engine,
+    get_firecrawl_api_url,
+    set_firecrawl_api_url,
+    DEFAULT_FIRECRAWL_API_URL,
     ALLOWED_DOCUMENT_ENGINES,
     ALLOWED_URL_ENGINES,
+    CONFIG,
 )
 
 
@@ -106,3 +110,68 @@ class TestEdgeCases:
         with patch.dict('os.environ', {'CCORE_DOCUMENT_ENGINE': ' auto '}):
             engine = get_document_engine()
             assert engine == "auto"  # Should fallback to default
+
+
+class TestFirecrawlApiUrl:
+    """Test Firecrawl API URL configuration."""
+
+    def test_default_firecrawl_api_url(self):
+        """Test default Firecrawl API URL when nothing is configured."""
+        # Clear env var and config
+        with patch.dict('os.environ', {}, clear=False):
+            if 'FIRECRAWL_API_BASE_URL' in __import__('os').environ:
+                del __import__('os').environ['FIRECRAWL_API_BASE_URL']
+            # Clear config override
+            if 'extraction' in CONFIG and 'firecrawl' in CONFIG['extraction']:
+                CONFIG['extraction']['firecrawl']['api_url'] = None
+            url = get_firecrawl_api_url()
+            assert url == DEFAULT_FIRECRAWL_API_URL
+            assert url == "https://api.firecrawl.dev"
+
+    def test_env_var_override(self):
+        """Test environment variable overrides default."""
+        custom_url = "http://localhost:3002"
+        with patch.dict('os.environ', {'FIRECRAWL_API_BASE_URL': custom_url}):
+            url = get_firecrawl_api_url()
+            assert url == custom_url
+
+    def test_yaml_config_override(self):
+        """Test YAML config overrides default when env var not set."""
+        custom_url = "http://firecrawl.internal:3002"
+        with patch.dict('os.environ', {}, clear=False):
+            if 'FIRECRAWL_API_BASE_URL' in __import__('os').environ:
+                del __import__('os').environ['FIRECRAWL_API_BASE_URL']
+            # Set config
+            CONFIG.setdefault('extraction', {}).setdefault('firecrawl', {})['api_url'] = custom_url
+            try:
+                url = get_firecrawl_api_url()
+                assert url == custom_url
+            finally:
+                # Clean up
+                CONFIG['extraction']['firecrawl']['api_url'] = None
+
+    def test_env_var_takes_precedence_over_config(self):
+        """Test environment variable takes precedence over YAML config."""
+        env_url = "http://env-firecrawl:3002"
+        config_url = "http://config-firecrawl:3002"
+        CONFIG.setdefault('extraction', {}).setdefault('firecrawl', {})['api_url'] = config_url
+        try:
+            with patch.dict('os.environ', {'FIRECRAWL_API_BASE_URL': env_url}):
+                url = get_firecrawl_api_url()
+                assert url == env_url
+        finally:
+            CONFIG['extraction']['firecrawl']['api_url'] = None
+
+    def test_set_firecrawl_api_url(self):
+        """Test programmatic override via set_firecrawl_api_url."""
+        custom_url = "http://programmatic:3002"
+        with patch.dict('os.environ', {}, clear=False):
+            if 'FIRECRAWL_API_BASE_URL' in __import__('os').environ:
+                del __import__('os').environ['FIRECRAWL_API_BASE_URL']
+            try:
+                set_firecrawl_api_url(custom_url)
+                url = get_firecrawl_api_url()
+                assert url == custom_url
+            finally:
+                # Clean up
+                CONFIG['extraction']['firecrawl']['api_url'] = None

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "content-core"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

- Add support for configuring a custom Firecrawl API base URL for self-hosted instances
- Configuration via environment variable `FIRECRAWL_API_BASE_URL`, YAML config, or programmatic API
- Debug logging when using a custom base URL
- Documentation with link to [Firecrawl self-hosting guide](https://github.com/mendableai/firecrawl/blob/main/SELF_HOST.md)

Closes lfnovo/open-notebook#174

## Changes

| File | Change |
|------|--------|
| `src/content_core/config.py` | Added `get_firecrawl_api_url()`, `set_firecrawl_api_url()`, `DEFAULT_FIRECRAWL_API_URL` |
| `src/content_core/processors/url.py` | Pass custom API URL to `AsyncFirecrawlApp` |
| `src/content_core/cc_config.yaml` | Added `firecrawl.api_url` config option |
| `tests/unit/test_config.py` | Added 5 tests for Firecrawl API URL configuration |
| `docs/usage.md` | Added "Self-Hosted Firecrawl" section |
| `docs/mcp.md` | Added self-hosting link and `FIRECRAWL_API_BASE_URL` to config example |
| `README.md` | Added `firecrawl.api_url` to config example |
| `CHANGELOG.md` | Added v1.11.0 release notes |
| `pyproject.toml` | Bumped version to 1.11.0 |

## Test plan

- [x] Unit tests pass (149 passed)
- [x] Tested with self-hosted Firecrawl instance on `http://localhost:3002`
- [x] Verified extraction works with custom base URL
- [x] Verified debug logging appears when using custom URL