### PR TITLE
feat: migrate to LangGraph v1 and add CLAUDE.md documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ WIP/
 
 *.ignore
 .windsurfrules
-CLAUDE.md
 
 node_modules/
 **/notebooks/private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-01-25
+
+### Changed
+- **LangGraph v1 Migration** - Updated to LangGraph v1.0+ (from v0.3.x)
+  - Minimum requirement now `langgraph>=1.0.0`
+  - Updated StateGraph API: `input` → `input_schema`, `output` → `output_schema`
+  - No breaking changes for users - same API surface maintained
+
 ## [1.11.0] - 2026-01-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# Content Core
+
+Library for extracting, cleaning, and summarizing content from URLs, files, and text.
+
+## Commands
+
+- **Install dependencies**: `uv sync --group dev`
+- **Run tests**: `make test` or `uv run pytest -v`
+- **Run single test**: `uv run pytest -k "test_name"`
+- **Linting**: `make ruff` (runs `ruff check . --fix`)
+- **Build package**: `uv build`
+- **Build docs**: `make build-docs`
+
+## Codebase Structure
+
+```
+src/content_core/
+├── __init__.py          # CLI entry points (ccore, cclean, csum) and public API
+├── config.py            # Configuration loading, engine selection, retry/proxy settings
+├── models.py            # ModelFactory for Esperanto LLM/STT model caching
+├── templated_message.py # LLM prompt execution with Jinja templates
+├── logging.py           # Loguru configuration
+│
+├── common/              # Shared infrastructure (see common/CLAUDE.md)
+│   ├── exceptions.py    # Exception hierarchy
+│   ├── retry.py         # Retry decorators for transient failures
+│   ├── state.py         # Pydantic state models for LangGraph
+│   ├── types.py         # Type aliases (DocumentEngine, UrlEngine)
+│   └── utils.py         # Input content processing
+│
+├── processors/          # Format-specific extractors (see processors/CLAUDE.md)
+│   ├── pdf.py           # PDF/EPUB via PyMuPDF
+│   ├── url.py           # URL extraction (jina/firecrawl/crawl4ai/bs4)
+│   ├── audio.py         # Audio transcription via Esperanto STT
+│   ├── video.py         # Video-to-audio via moviepy
+│   ├── youtube.py       # YouTube transcript extraction
+│   ├── office.py        # Office docs (docx/pptx/xlsx)
+│   ├── text.py          # Plain text files
+│   └── docling.py       # Optional Docling integration
+│
+├── content/             # High-level workflows
+│   ├── extraction/      # LangGraph extraction workflow
+│   │   └── graph.py     # Main extraction state graph
+│   ├── identification/  # File type detection
+│   │   └── file_detector.py
+│   ├── cleanup/         # Content cleaning via LLM
+│   └── summary/         # Content summarization via LLM
+│
+├── tools/               # LangChain tool wrappers (see tools/CLAUDE.md)
+│   ├── extract.py       # extract_content_tool
+│   ├── cleanup.py       # cleanup_content_tool
+│   └── summarize.py     # summarize_content_tool
+│
+└── mcp/                 # MCP server for AI assistant integration
+    └── server.py        # FastMCP server implementation
+```
+
+## Architecture
+
+**Data flow**: Input -> LangGraph workflow -> Processor -> Output
+
+1. `ProcessSourceInput` received via API or CLI
+2. `content/extraction/graph.py` routes to appropriate processor based on source type
+3. Processor extracts content and returns state updates
+4. `ProcessSourceOutput` returned to caller
+
+**Key patterns**:
+- LangGraph StateGraph orchestrates extraction workflow
+- Processors are stateless functions that take `ProcessSourceState` and return dict updates
+- Retry decorators handle transient failures for network/API operations
+- Configuration loaded from YAML with env var overrides
+
+## Integration
+
+- **Esperanto**: LLM and STT model abstraction via `ModelFactory`
+- **LangGraph**: Workflow orchestration in `content/extraction/graph.py`
+- **LangChain**: Tool wrappers in `tools/` for agent integration
+- **ai-prompter**: Template rendering in `templated_message.py`
+
+## Gotchas
+
+- Import aliases: `content_core.extraction` = `content_core.content.extraction`
+- `docling` is optional: check `DOCLING_AVAILABLE` before using
+- Proxy must be passed through state or config, not set globally on requests
+- All async operations should use retry decorators for resilience
+- `ModelFactory` caches models but invalidates on proxy change
+
+## Code Style
+
+- **Formatting**: Follow PEP 8
+- **Imports**: Organize by standard library, third-party, local
+- **Error handling**: Use custom exceptions from `common/exceptions.py`
+- **Documentation**: Update docs when changing functionality
+- **Tests**: Write unit tests for new code; integration tests for workflows
+
+## Release Process
+
+1. Run `make test` to verify everything works
+2. Update version in `pyproject.toml`
+3. Run `uv sync` to update the lock file
+4. Commit changes
+5. Merge to main (if in a branch)
+6. Tag the release
+7. Push to GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-core"
-version = "1.11.0"
+version = "1.12.0"
 description = "Extract what matters from any media source. Available as Python Library, macOS Service, CLI and MCP Server"
 readme = "README.md"
 homepage = "https://github.com/lfnovo/content-core"
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.11",
     "bs4>=0.0.2",
-    "esperanto>=2.14.0",
+    "esperanto>=2.17.0",
     "jinja2>=3.1.6",
     "langdetect>=1.0.9",
     "loguru>=0.7.3",
@@ -22,7 +22,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "python-pptx>=1.0.2",
     "youtube-transcript-api>=1.0.3",
-    "langgraph>=0.3.29",
+    "langgraph>=1.0.0",
     "dicttoxml>=1.7.16",
     "validators>=0.34.0",
     "ai-prompter>=0.2.3",

--- a/src/content_core/common/CLAUDE.md
+++ b/src/content_core/common/CLAUDE.md
@@ -1,0 +1,36 @@
+# Common Module
+
+Shared infrastructure for content-core: exceptions, retry logic, state management, and utilities.
+
+## Files
+
+- **`exceptions.py`**: Exception hierarchy with `ContentCoreError` as base. Key exceptions: `UnsupportedTypeException`, `InvalidInputError`, `NotFoundError`, `NoTranscriptFound`, `NetworkError`
+- **`retry.py`**: Tenacity-based retry decorators for transient failures. Uses `get_retry_config()` from config. Exports: `retry_youtube`, `retry_url_api`, `retry_url_network`, `retry_audio_transcription`, `retry_llm`, `retry_download`
+- **`state.py`**: Pydantic models for LangGraph workflow state. `ProcessSourceInput` (API input), `ProcessSourceState` (internal state), `ProcessSourceOutput` (API output)
+- **`types.py`**: Type aliases for engine selection: `DocumentEngine`, `UrlEngine`
+- **`utils.py`**: Helper `process_input_content()` to detect and extract from URLs/files
+
+## Patterns
+
+- **Exception handling**: All custom exceptions inherit from `ContentCoreError`. Use specific exceptions like `UnsupportedTypeException` for type mismatches
+- **Retry decorators**: Applied as function decorators, not class methods. They read config via `get_retry_config(operation_type)`. Non-retryable exceptions (e.g., `NotFoundError`, `NoTranscriptFound`) bypass retry
+- **State flow**: `ProcessSourceInput` -> `ProcessSourceState` (internal) -> `ProcessSourceOutput`. State models use optional fields with defaults
+
+## Integration
+
+- Imported by: All processors, extraction graph, tools, templated_message
+- Imports from: `content_core.config`, `content_core.logging`
+- `retry.py` depends on `config.get_retry_config()` for retry parameters
+
+## Gotchas
+
+- Retry decorators must wrap internal functions (prefixed with `_`), not the public API functions
+- `NON_RETRYABLE_EXCEPTIONS` in retry.py determines which errors skip retry - add new permanent failure types there
+- `ProcessSourceState` has more fields than `ProcessSourceInput` - it accumulates data during workflow execution
+- `process_input_content()` uses validators library for URL detection, regex for file paths
+
+## When Adding Code
+
+- New exceptions must inherit from `ContentCoreError`
+- New retry decorators should follow the pattern: config lookup, tenacity decorator, before_sleep logging
+- State fields should be Optional with defaults to support partial workflow execution

--- a/src/content_core/content/extraction/graph.py
+++ b/src/content_core/content/extraction/graph.py
@@ -185,7 +185,7 @@ async def file_type_router_docling(state: ProcessSourceState) -> str:
 
 # Create workflow
 workflow = StateGraph(
-    ProcessSourceState, input=ProcessSourceInput, output=ProcessSourceState
+    ProcessSourceState, input_schema=ProcessSourceInput, output_schema=ProcessSourceState
 )
 
 # Add nodes

--- a/src/content_core/processors/CLAUDE.md
+++ b/src/content_core/processors/CLAUDE.md
@@ -1,0 +1,43 @@
+# Processors Module
+
+Format-specific content extraction handlers. Each processor extracts content from a specific file type or source.
+
+## Files
+
+- **`pdf.py`**: PDF/EPUB extraction using PyMuPDF (fitz). Handles table detection, OCR fallback for formulas, text cleaning. Exports `SUPPORTED_FITZ_TYPES`, `extract_pdf`
+- **`url.py`**: URL content extraction with multiple engines (simple/jina/firecrawl/crawl4ai). Handles MIME type detection via HEAD request. Exports `url_provider`, `extract_url`
+- **`audio.py`**: Audio transcription using Esperanto STT models. Handles segmentation for long files, parallel transcription with semaphore. Exports `extract_audio_data`
+- **`video.py`**: Video-to-audio extraction using moviepy. Extracts audio track for transcription pipeline. Exports `extract_best_audio_from_video`
+- **`youtube.py`**: YouTube transcript extraction using youtube-transcript-api. Handles multiple transcript formats, language fallbacks. Exports `extract_youtube_transcript`
+- **`office.py`**: Office document extraction (docx, pptx, xlsx) using python-docx, python-pptx, openpyxl. Exports `SUPPORTED_OFFICE_TYPES`, `extract_office_content`
+- **`text.py`**: Plain text file reading. Simple file read operation. Exports `extract_txt`
+- **`docling.py`**: Optional Docling-based extraction for advanced document processing. Conditionally imported. Exports `DOCLING_AVAILABLE`, `DOCLING_SUPPORTED`, `extract_with_docling`
+
+## Patterns
+
+- **Function signature**: All extract functions take `ProcessSourceState` and return `Dict[str, Any]` with content/metadata updates
+- **Async execution**: CPU-bound work runs in thread pool via `asyncio.get_event_loop().run_in_executor()`
+- **Retry decorators**: Network operations wrapped with retry decorators from `common.retry`
+- **Engine selection**: URL and document engines selected via `config.get_url_engine()` / `config.get_document_engine()`
+- **Type constants**: Each processor exports `SUPPORTED_*_TYPES` lists used by the routing graph
+
+## Integration
+
+- Called by: `content/extraction/graph.py` via LangGraph nodes
+- Imports from: `content_core.common`, `content_core.config`, `content_core.logging`, `content_core.models`
+- `audio.py` uses `ModelFactory.get_model("speech_to_text")` for STT
+
+## Gotchas
+
+- `docling.py` is conditionally imported - check `DOCLING_AVAILABLE` before using
+- `url.py` fallback chain: Firecrawl (if API key) -> Jina -> Crawl4AI -> BeautifulSoup
+- `audio.py` segments files >10 min and processes in parallel with configurable concurrency
+- `pdf.py` OCR is disabled by default - enable via config `extraction.pymupdf.enable_formula_ocr`
+- All processors must handle the `proxy` field from state when making network requests
+
+## When Adding Code
+
+- New processors must: accept `ProcessSourceState`, return dict with state updates, handle errors gracefully
+- Add new MIME types to the appropriate `SUPPORTED_*_TYPES` constant
+- Network operations should use retry decorators and `get_proxy()` for proxy support
+- Register new processors as nodes in `content/extraction/graph.py`

--- a/src/content_core/tools/CLAUDE.md
+++ b/src/content_core/tools/CLAUDE.md
@@ -1,0 +1,31 @@
+# Tools Module
+
+LangChain tool wrappers for content-core operations. Provides `@tool` decorated functions for agent integration.
+
+## Files
+
+- **`extract.py`**: `extract_content_tool` - extracts content from URLs or file paths
+- **`cleanup.py`**: `cleanup_content_tool` - cleans and rewrites content with LLM
+- **`summarize.py`**: `summarize_content_tool` - summarizes content with optional context
+
+## Patterns
+
+- **Tool decorator**: All functions use `@tool` from `langchain_core.tools`
+- **Input preprocessing**: Tools call `process_input_content()` to handle URL/file path inputs before processing
+- **Async**: All tool functions are async
+
+## Integration
+
+- Imports from: `content_core.extraction`, `content_core.content_cleanup`, `content_core.content_summary`, `content_core.common`
+- Used by: External agents using LangChain/LangGraph
+
+## Gotchas
+
+- Tools auto-extract content from URLs/files via `process_input_content()` before processing
+- Import paths use aliases: `content_core.extraction` (not `content_core.content.extraction`)
+
+## When Adding Code
+
+- New tools must use `@tool` decorator and be async
+- Add new tools to `__init__.py` exports
+- Use `process_input_content()` if the tool should accept URLs/file paths as input

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "content-core"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },
@@ -747,12 +747,12 @@ requires-dist = [
     { name = "crawl4ai", marker = "extra == 'crawl4ai'", specifier = ">=0.7.0" },
     { name = "dicttoxml", specifier = ">=1.7.16" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.34.0" },
-    { name = "esperanto", specifier = ">=2.14.0" },
+    { name = "esperanto", specifier = ">=2.17.0" },
     { name = "fastmcp", specifier = ">=2.10.0" },
     { name = "firecrawl-py", specifier = ">=2.7.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langdetect", specifier = ">=1.0.9" },
-    { name = "langgraph", specifier = ">=0.3.29" },
+    { name = "langgraph", specifier = ">=1.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "moviepy", specifier = ">=2.1.2" },
     { name = "openpyxl", specifier = ">=3.1.5" },
@@ -1174,15 +1174,15 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.15.0"
+version = "2.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/c8/85c4629956a5b30275f56bf6e021e25d9be1a2eea0a66c898440f2c3537a/esperanto-2.15.0.tar.gz", hash = "sha256:dbae1a5915c5026299fca8d5d7a4596a67885bc39196c326ff64eb7e63ed6de4", size = 773688, upload-time = "2026-01-16T19:49:44.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/0d/1607a3a46421c63d81a56002f489c25424761b8589022289dec64d324efd/esperanto-2.17.2.tar.gz", hash = "sha256:6e96db87f6a4faa1387554be9feefb2d6de761b2368c45ddf0a9967c1d1064cb", size = 850259, upload-time = "2026-01-24T12:32:48.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/ff/dc6820f25e5943afb8622763a4dfc6cf9fb59b347753e481cc425cd14b24/esperanto-2.15.0-py3-none-any.whl", hash = "sha256:dedf53fe7a20695bb94fadd29be51082a3de5fa4a6cd03be6f38fe26bf6187a5", size = 178768, upload-time = "2026-01-16T19:49:45.604Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/43/c83db99f2e24b50cedf05730a229df67cd0720b5bb0bc980a1b1246d19d9/esperanto-2.17.2-py3-none-any.whl", hash = "sha256:db6530794de7dc5be0a1196e9a9444c89934ec0af4a55792fb6daa1bb7a2cb3e", size = 201438, upload-time = "2026-01-24T12:32:50.619Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrate from LangGraph v0.3.x to v1.0+
- Fix deprecation warnings in StateGraph API (`input` → `input_schema`, `output` → `output_schema`)
- Add CLAUDE.md documentation files for AI-assisted development context
- Bump version to 1.12.0

## Changes

### LangGraph v1 Migration
- Updated `langgraph>=0.3.29` to `langgraph>=1.0.0` in pyproject.toml
- Updated `StateGraph` instantiation in `graph.py` to use new parameter names

### CLAUDE.md Documentation
Added AI context documentation for:
- Root level: codebase structure, architecture, integration points
- `common/`: shared infrastructure (exceptions, retry, state)
- `processors/`: format-specific extractors
- `tools/`: LangChain tool wrappers

## Test plan

- [x] All tests pass (209 passed, 1 YouTube flaky test, 5 skipped)
- [x] No LangGraph deprecation warnings
- [x] Core extraction workflow verified (text, PDF, URL)