### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ summary = await cc.summarize_content(result, context="explain to a child")
 *   **🔄 Asynchronous:** Built with `asyncio` for efficient processing
 *   **🐍 Pure Python Implementation:** No system dependencies required - simplified installation across all platforms
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/lfnovo-content-core).
+
 ## Getting Started
 
 ### Installation


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/lfnovo-content-core)