### PR TITLE
fix: recognize YouTube /live/ and /shorts/ URLs

### DIFF
--- a/src/content_core/processors/url/youtube.py
+++ b/src/content_core/processors/url/youtube.py
@@ -60,6 +60,8 @@ async def _extract_youtube_id(url):
         r"(?:"  # Group start
         r"/embed/"  # Embed URL
         r"|/v/"  # Older video URL
+        r"|/live/"  # Livestream URL (active or ended)
+        r"|/shorts/"  # Shorts URL
         r"|/watch\?v="  # Standard watch URL
         r"|/watch\?.+&v="  # Other watch URL
         r")"  # Group end

--- a/tests/unit/test_youtube_parsing.py
+++ b/tests/unit/test_youtube_parsing.py
@@ -25,6 +25,18 @@ class TestExtractYoutubeId:
         )
         assert result == "dQw4w9WgXcQ"
 
+    async def test_live_url(self):
+        result = await _extract_youtube_id(
+            "https://www.youtube.com/live/dQw4w9WgXcQ"
+        )
+        assert result == "dQw4w9WgXcQ"
+
+    async def test_shorts_url(self):
+        result = await _extract_youtube_id(
+            "https://www.youtube.com/shorts/dQw4w9WgXcQ"
+        )
+        assert result == "dQw4w9WgXcQ"
+
     async def test_url_with_extra_params(self):
         result = await _extract_youtube_id(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120"


### PR DESCRIPTION
Closes #39

## Problem

`youtube.com/live/<id>` URLs (scheduled or ended livestreams) and `youtube.com/shorts/<id>` were not matched by the YouTube URL parser, so the extracted video ID was `None` and both `get_video_title` and `get_best_transcript` failed downstream:

```
ERROR content_core.processors.url.youtube:get_video_title:39
  Failed to get video title after retries: 'NoneType' object is not subscriptable
```

## Fix

Added `/live/` and `/shorts/` as alternatives in the existing video-ID regex in `processors/url/youtube.py`. No change to any existing match path — it only widens recognition.

## Tests

Added `test_live_url` and `test_shorts_url` to `tests/unit/test_youtube_parsing.py`. Full youtube suite green (20 passed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

