### PR TITLE
feat: public check_file_support pre-flight validation API

### DIFF
--- a/src/content_core/__init__.py
+++ b/src/content_core/__init__.py
@@ -5,9 +5,9 @@ load_dotenv()
 
 from content_core.config import ContentCoreConfig
 from content_core.content.summary import summarize
-from content_core.extraction import extract_content
+from content_core.extraction import check_file_support, extract_content
 from content_core.logging import configure_logging
-from content_core.common.state import ExtractionInput, ExtractionOutput
+from content_core.common.state import ExtractionInput, ExtractionOutput, FileSupport
 
 # Convenience alias
 extract = extract_content
@@ -18,8 +18,10 @@ configure_logging(debug=False)
 __all__ = [
     "extract_content",
     "extract",
+    "check_file_support",
     "summarize",
     "ContentCoreConfig",
     "ExtractionInput",
     "ExtractionOutput",
+    "FileSupport",
 ]

--- a/src/content_core/common/state.py
+++ b/src/content_core/common/state.py
@@ -29,7 +29,24 @@ class ExtractionOutput(BaseModel):
     metadata: dict = Field(default_factory=dict)
 
 
+class FileSupport(BaseModel):
+    """Verdict from a pre-flight file-support check.
+
+    Returned by ``check_file_support`` so callers can validate an upload
+    cheaply (identification + routing only, no extraction) before committing
+    to a full extraction job.
+    """
+
+    supported: bool
+    file_path: str
+    identified_type: str = ""  # MIME type detected for the file
+    document_engine: str = ""  # engine the verdict was computed for
+    processor: Optional[str] = None  # processor that would handle it, if supported
+    reason: Optional[str] = None  # human-readable explanation when unsupported
+
+
 __all__ = [
     "ExtractionInput",
     "ExtractionOutput",
+    "FileSupport",
 ]

--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -11,7 +11,7 @@ from content_core.common.exceptions import InvalidInputError, UnsupportedTypeExc
 from content_core.common.retry import retry_download
 from content_core.config import ContentCoreConfig, get_default_config
 from content_core.logging import logger
-from content_core.common.state import ExtractionOutput
+from content_core.common.state import ExtractionOutput, FileSupport
 
 # Import processor v2 functions
 from content_core.processors.media.audio import transcribe_audio
@@ -105,6 +105,90 @@ async def _extract_url(url: str, cfg: ContentCoreConfig) -> ExtractionOutput:
     return await extract_from_url(url, cfg)
 
 
+def _route_for_mime(mime: str, cfg: ContentCoreConfig) -> str | None:
+    """Return the processor that would handle a file of this MIME type.
+
+    Single source of truth for file-support routing, shared by ``_extract_file``
+    (actual extraction) and ``check_file_support`` (pre-flight validation), so
+    the pre-flight answer can never disagree with what extraction really does.
+
+    Returns the processor name ("docling", "pdf", "epub", "office", "video",
+    "audio", "text") or ``None`` if the type is unsupported.
+    """
+    engine = cfg.document_engine
+    if engine == "docling" or (
+        engine == "auto" and DOCLING_AVAILABLE and mime in DOCLING_SUPPORTED
+    ):
+        if DOCLING_AVAILABLE and extract_docling is not None:
+            return "docling"
+
+    if mime in SUPPORTED_PDF_TYPES:
+        return "pdf"
+    if mime in SUPPORTED_EPUB_TYPES:
+        return "epub"
+    if mime in SUPPORTED_OFFICE_TYPES:
+        return "office"
+    if mime.startswith("video/"):
+        return "video"
+    if mime.startswith("audio/"):
+        return "audio"
+    if mime == "text/plain":
+        return "text"
+    return None
+
+
+async def check_file_support(
+    file_path: str, config: ContentCoreConfig | None = None
+) -> FileSupport:
+    """Check whether content-core can extract a given file, without extracting.
+
+    Runs the same identification + routing that ``extract_content`` uses, but
+    stops before extraction, so the answer carries the same authority as a real
+    run at a fraction of the cost (it only reads the file header). "Unsupported"
+    is returned as a verdict rather than raised, since it is an expected outcome
+    at ingestion time.
+
+    Args:
+        file_path: Local file path to validate.
+        config: Optional config override. The ``document_engine`` setting is
+            honored, since supported types vary by engine.
+
+    Returns:
+        FileSupport verdict with ``supported``, the ``identified_type`` (MIME),
+        the ``processor`` that would handle it (when supported), and a ``reason``
+        when it would not.
+    """
+    from content_core.content.identification import get_file_type
+
+    cfg = config or get_default_config()
+
+    # Identification can fail outright for unrecognizable files -- that is itself
+    # an "unsupported" verdict (extract_content would raise here too), not an
+    # error the caller should have to catch.
+    try:
+        mime = await get_file_type(file_path)
+    except UnsupportedTypeException as exc:
+        return FileSupport(
+            supported=False,
+            file_path=file_path,
+            identified_type="",
+            document_engine=cfg.document_engine,
+            processor=None,
+            reason=str(exc),
+        )
+
+    processor = _route_for_mime(mime, cfg)
+    supported = processor is not None
+    return FileSupport(
+        supported=supported,
+        file_path=file_path,
+        identified_type=mime,
+        document_engine=cfg.document_engine,
+        processor=processor,
+        reason=None if supported else f"Unsupported file type: {mime}",
+    )
+
+
 async def _extract_file(
     path: str, cfg: ContentCoreConfig, delete_after: bool = False
 ) -> ExtractionOutput:
@@ -116,32 +200,30 @@ async def _extract_file(
 
     used_docling = False
     try:
+        route = _route_for_mime(mime, cfg)
+
         # Docling routing (if enabled and supported)
-        engine = cfg.document_engine
-        if engine == "docling" or (
-            engine == "auto" and DOCLING_AVAILABLE and mime in DOCLING_SUPPORTED
-        ):
-            if DOCLING_AVAILABLE and extract_docling is not None:
-                used_docling = True
-                result = await extract_docling(path, cfg)
-                if not result.title:
-                    result.title = os.path.basename(path)
-                result.identified_type = mime
-                result.source_type = "file"
-                return result
+        if route == "docling":
+            used_docling = True
+            result = await extract_docling(path, cfg)
+            if not result.title:
+                result.title = os.path.basename(path)
+            result.identified_type = mime
+            result.source_type = "file"
+            return result
 
         # Standard processors
-        if mime in SUPPORTED_PDF_TYPES:
+        if route == "pdf":
             result = await extract_pdf_file(path, cfg)
-        elif mime in SUPPORTED_EPUB_TYPES:
+        elif route == "epub":
             result = await extract_epub_file(path, cfg)
-        elif mime in SUPPORTED_OFFICE_TYPES:
+        elif route == "office":
             result = await extract_office(path, mime, cfg)
-        elif mime.startswith("video/"):
+        elif route == "video":
             result = await extract_video(path, cfg)
-        elif mime.startswith("audio/"):
+        elif route == "audio":
             result = await transcribe_audio(path, cfg)
-        elif mime == "text/plain":
+        elif route == "text":
             result = await extract_text_file(path, cfg)
         else:
             raise UnsupportedTypeException(f"Unsupported file type: {mime}")

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -7,8 +7,8 @@ import pytest
 
 from content_core.common.exceptions import InvalidInputError, UnsupportedTypeException
 from content_core.config import ContentCoreConfig
-from content_core.extraction import extract_content
-from content_core.common.state import ExtractionOutput
+from content_core.extraction import check_file_support, extract_content
+from content_core.common.state import ExtractionOutput, FileSupport
 
 
 def _make_output(**kwargs) -> ExtractionOutput:
@@ -324,3 +324,86 @@ async def test_docling_flags_warning_without_engine():
 
         mock_logger.warning.assert_called_once()
         assert "docling" in mock_logger.warning.call_args[0][0].lower()
+
+
+# ---------------------------------------------------------------------------
+# 14. check_file_support pre-flight verdict
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_check_file_support_supported():
+    cfg = ContentCoreConfig(document_engine="simple")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ):
+        result = await check_file_support("/tmp/test.pdf", config=cfg)
+    assert isinstance(result, FileSupport)
+    assert result.supported is True
+    assert result.identified_type == "application/pdf"
+    assert result.processor == "pdf"
+    assert result.reason is None
+    assert result.document_engine == "simple"
+    assert result.file_path == "/tmp/test.pdf"
+
+
+@pytest.mark.asyncio
+async def test_check_file_support_unsupported():
+    cfg = ContentCoreConfig(document_engine="simple")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/x-unknown-binary",
+    ):
+        result = await check_file_support("/tmp/test.bin", config=cfg)
+    assert result.supported is False
+    assert result.processor is None
+    assert result.reason is not None
+    assert "application/x-unknown-binary" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_check_file_support_unidentifiable_returns_verdict():
+    """A file whose type can't be determined is a verdict, not a raised error."""
+    cfg = ContentCoreConfig(document_engine="simple")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        side_effect=UnsupportedTypeException("Unable to determine file type for: x"),
+    ):
+        result = await check_file_support("/tmp/mystery.xyz", config=cfg)
+    assert result.supported is False
+    assert result.processor is None
+    assert result.identified_type == ""
+    assert "determine file type" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_check_file_support_does_not_extract():
+    """The pre-flight check must never invoke a real extractor."""
+    cfg = ContentCoreConfig(document_engine="simple")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.extract_pdf_file", new_callable=AsyncMock
+    ) as mock_pdf:
+        await check_file_support("/tmp/test.pdf", config=cfg)
+        mock_pdf.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_file_support_agrees_with_extraction():
+    """The verdict must never disagree with what extract_content actually does."""
+    cfg = ContentCoreConfig(document_engine="simple")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/x-unknown-binary",
+    ):
+        verdict = await check_file_support("/tmp/test.bin", config=cfg)
+        assert verdict.supported is False
+        # extraction of the same type raises, confirming the verdict
+        with pytest.raises(UnsupportedTypeException):
+            await extract_content(file_path="/tmp/test.bin", config=cfg)


### PR DESCRIPTION
Closes #41

## Summary

Adds a public `check_file_support(file_path, config)` that answers **"can content-core process this file?"** cheaply — identification + routing only, no extraction — so consumers (e.g. Open Notebook) can validate uploads at ingestion time instead of discovering `UnsupportedTypeException` deep inside a background job (which previously burned ~1h of retry backoff before failing).

```python
from content_core import check_file_support

result = await check_file_support("/path/to/file.odt")
if not result.supported:
    reject(result.reason)          # e.g. "Unsupported file type: application/vnd.oasis..."
```

Returns a `FileSupport` verdict: `supported`, `identified_type` (MIME), `processor` (which extractor would handle it), `document_engine`, and `reason` when unsupported.

## Design

- **Single source of truth:** routing logic is factored into `_route_for_mime(mime, cfg)`, now shared by both `_extract_file` (real extraction) and `check_file_support` (pre-flight). The verdict therefore **can never disagree** with what extraction actually does.
- **Verdict, not raise:** at ingestion "unsupported" is an expected outcome, so it is returned rather than raised — including files whose type cannot be identified at all (`get_file_type` raising is caught and mapped to `supported=False`). See issue thread for the full rationale.
- **Engine-aware:** honors `document_engine`, since supported types vary by engine (docling vs. default).

## Tests

- 6 new unit tests in `test_routing.py`: supported, unsupported, unidentifiable, does-not-extract, and an agrees-with-extraction consistency check.
- Refactor of `_extract_file` validated by the full existing routing + integration suites.
- Full gate green: `290 passed` (unit + integration). Verified end-to-end against real PDF/DOCX/unknown files.

No behavior change to `extract_content`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

