### PR TITLE
feat(docling): support external Docling Serve API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- First-class support for remote Docling Serve document extraction via `DOCLING_API_URL` / `docling_api_url`, with per-request precedence over local Docling
+- New Docling Serve config fields: `docling_api_url`, `docling_api_key`, and `docling_timeout`
+
+### Changed
+- Docling routing in `document_engine="auto"` now treats a configured Docling Serve API as Docling capability even when local Docling is not installed
+
+### Fixed
+- Remote Docling extraction now raises actionable errors for connection failures, timeouts, HTTP errors, malformed responses, and empty conversion results instead of silently falling back
+
 ## [2.0.4] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,11 @@ from content_core import ContentCoreConfig
 config = ContentCoreConfig(url_engine="firecrawl", audio_concurrency=5)
 ```
 
-Key settings: `url_engine`, `document_engine`, `audio_provider`, `audio_model`, `firecrawl_api_url`, `youtube_languages`, `llm_provider`, `llm_model`, `docling_ocr`, `docling_formulas`, `docling_vision`
+Key settings: `url_engine`, `document_engine`, `audio_provider`, `audio_model`, `firecrawl_api_url`, `youtube_languages`, `llm_provider`, `llm_model`, `docling_ocr`, `docling_formulas`, `docling_vision`, `docling_api_url`, `docling_api_key`, `docling_timeout`
 
 Docling enrichment flags (`docling_ocr`, `docling_formulas`, `docling_vision`) control OCR, formula extraction, and image/chart processing when `document_engine="docling"`. These are also exposed as CLI flags (`--formulas`, `--pictures`, `--no-ocr`) and MCP parameters.
+
+Remote Docling Serve can be configured with `docling_api_url`, `docling_api_key`, and `docling_timeout`. The settings model accepts both the `CCORE_`-prefixed names and the standard `DOCLING_API_URL` / `DOCLING_API_KEY` environment variables.
 
 Priority: constructor args > env vars (`CCORE_*`) > config file (`~/.content-core/config.toml`) > defaults
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ config = ContentCoreConfig(
 result = await content_core.extract_content(url="https://example.com", config=config)
 ```
 
-Remote Docling Serve is also supported for document extraction. When `docling_api_url`
+Remote Docling Serve is also supported for document extraction. Remote Docling routing
+applies only when `document_engine` is `auto` or `docling`. When `docling_api_url`
 is configured, Content Core uploads local documents to Docling Serve via
 `POST /v1/convert/file` and returns `document.md_content` from the synchronous JSON
 response. If `docling_api_url` is not configured, Content Core preserves the existing
@@ -242,9 +243,12 @@ API keys for external services are set via their standard environment variables 
 
 For supported document types, Content Core resolves Docling extraction in this order:
 
-1. If `docling_api_url` or `DOCLING_API_URL` is configured, use the external Docling Serve API.
+1. If `document_engine` is `auto` or `docling` and `docling_api_url` or `DOCLING_API_URL` is configured, use the external Docling Serve API.
 2. Otherwise, if local Docling is installed, use the existing in-process Docling converter.
 3. Otherwise, preserve the current simple-engine fallback behavior.
+
+When `document_engine` is `simple`, Docling is bypassed (including remote Docling Serve),
+and Content Core uses simple document processors only.
 
 When the remote Docling Serve API is configured, Content Core does not silently fall back
 to local Docling on API failures. Connection failures, timeouts, HTTP errors, malformed

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ config = ContentCoreConfig(
 result = await content_core.extract_content(url="https://example.com", config=config)
 ```
 
+Remote Docling Serve is also supported for document extraction. When `docling_api_url`
+is configured, Content Core uploads local documents to Docling Serve via
+`POST /v1/convert/file` and returns `document.md_content` from the synchronous JSON
+response. If `docling_api_url` is not configured, Content Core preserves the existing
+local Docling behavior when the optional dependency is installed.
+
 ## MCP Integration
 
 Content Core includes a Model Context Protocol (MCP) server for use with Claude Desktop and other MCP-compatible applications.
@@ -217,6 +223,9 @@ Content Core uses `ContentCoreConfig` powered by pydantic-settings. Settings are
 | `CCORE_DOCUMENT_ENGINE` | Document extraction engine (`auto`, `simple`, `docling`) | `auto` |
 | `CCORE_AUDIO_CONCURRENCY` | Concurrent audio transcriptions (1-10) | `3` |
 | `CRAWL4AI_API_URL` | Crawl4AI Docker API URL (omit for local browser mode) | - |
+| `DOCLING_API_URL` | Docling Serve base URL for remote document extraction | - |
+| `DOCLING_API_KEY` | Docling Serve API key sent as `X-Api-Key` | - |
+| `CCORE_DOCLING_TIMEOUT` | Docling Serve request timeout in seconds | `300` |
 | `FIRECRAWL_API_URL` | Custom Firecrawl API URL for self-hosted instances | - |
 | `CCORE_FIRECRAWL_PROXY` | Firecrawl proxy mode (`auto`, `basic`, `stealth`) | `auto` |
 | `CCORE_FIRECRAWL_WAIT_FOR` | Wait time in ms before extraction | `3000` |
@@ -228,6 +237,18 @@ Content Core uses `ContentCoreConfig` powered by pydantic-settings. Settings are
 | `CCORE_YOUTUBE_LANGUAGES` | Preferred YouTube transcript languages | - |
 
 API keys for external services are set via their standard environment variables (e.g., `OPENAI_API_KEY`, `FIRECRAWL_API_KEY`, `JINA_API_KEY`).
+
+### Docling Routing Precedence
+
+For supported document types, Content Core resolves Docling extraction in this order:
+
+1. If `docling_api_url` or `DOCLING_API_URL` is configured, use the external Docling Serve API.
+2. Otherwise, if local Docling is installed, use the existing in-process Docling converter.
+3. Otherwise, preserve the current simple-engine fallback behavior.
+
+When the remote Docling Serve API is configured, Content Core does not silently fall back
+to local Docling on API failures. Connection failures, timeouts, HTTP errors, malformed
+responses, and empty/missing markdown content raise a clear extraction error instead.
 
 ### Proxy Configuration
 

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -110,12 +110,14 @@ The `document_engine` setting controls document processing. When set to `auto` (
 
 - File: `document/docling.py`
 - Supports two backends selected per request config:
-  - Remote Docling Serve via `DOCLING_API_URL` / `docling_api_url`
+  - Remote Docling Serve via `docling_api_url`, `DOCLING_API_URL`, or `CCORE_DOCLING_API_URL`
   - Local Docling via `pip install content-core[docling]`
 - Supports PDF, DOCX, PPTX, XLSX, Markdown, AsciiDoc, HTML, CSV, and images
 - Remote Docling Serve currently returns markdown from the synchronous `POST /v1/convert/file` API
 - Local Docling preserves configurable output format: markdown (default), HTML, or JSON
 - Provides richer structural parsing than the simple engine
+- Remote routing is considered only when `document_engine` is `auto` or `docling`
+- `document_engine=simple` bypasses Docling entirely (remote and local)
 - Routing precedence is remote API first, then local Docling, then the existing simple fallback
 
 ## Media Processors

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -109,10 +109,14 @@ The `document_engine` setting controls document processing. When set to `auto` (
 ### Docling (Optional)
 
 - File: `document/docling.py`
-- Requires `pip install content-core[docling]`
+- Supports two backends selected per request config:
+  - Remote Docling Serve via `DOCLING_API_URL` / `docling_api_url`
+  - Local Docling via `pip install content-core[docling]`
 - Supports PDF, DOCX, PPTX, XLSX, Markdown, AsciiDoc, HTML, CSV, and images
-- Configurable output format: markdown (default), HTML, or JSON
+- Remote Docling Serve currently returns markdown from the synchronous `POST /v1/convert/file` API
+- Local Docling preserves configurable output format: markdown (default), HTML, or JSON
 - Provides richer structural parsing than the simple engine
+- Routing precedence is remote API first, then local Docling, then the existing simple fallback
 
 ## Media Processors
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,6 +73,7 @@ config = ContentCoreConfig(document_engine="docling", docling_output_format="htm
 result = await content_core.extract_content(file_path="report.pdf", config=config)
 
 # Or route document extraction through an external Docling Serve instance
+# (no local content-core[docling] installation required)
 remote_config = ContentCoreConfig(
     docling_api_url="http://localhost:5001",
     docling_ocr=True,
@@ -81,10 +82,14 @@ remote_config = ContentCoreConfig(
 result = await content_core.extract_content(file_path="report.pdf", config=remote_config)
 ```
 
-When `docling_api_url` is configured, Content Core uses Docling Serve's synchronous
+When `docling_api_url` is configured and `document_engine` is `auto` or `docling`,
+Content Core uses Docling Serve's synchronous
 `POST /v1/convert/file` endpoint with multipart field `files`, sends `to_formats=md`
 and `do_ocr`, and reads markdown from `document.md_content`. Remote failures are raised
 as extraction errors; they do not fall back to local Docling automatically.
+
+When `document_engine="simple"`, Content Core bypasses Docling (remote and local) and
+uses the simple document processors.
 
 ### Audio and Video
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,7 +71,20 @@ result = await content_core.extract_content(file_path="data.xlsx")
 from content_core import ContentCoreConfig
 config = ContentCoreConfig(document_engine="docling", docling_output_format="html")
 result = await content_core.extract_content(file_path="report.pdf", config=config)
+
+# Or route document extraction through an external Docling Serve instance
+remote_config = ContentCoreConfig(
+    docling_api_url="http://localhost:5001",
+    docling_ocr=True,
+    docling_timeout=300,
+)
+result = await content_core.extract_content(file_path="report.pdf", config=remote_config)
 ```
+
+When `docling_api_url` is configured, Content Core uses Docling Serve's synchronous
+`POST /v1/convert/file` endpoint with multipart field `files`, sends `to_formats=md`
+and `do_ocr`, and reads markdown from `document.md_content`. Remote failures are raised
+as extraction errors; they do not fall back to local Docling automatically.
 
 ### Audio and Video
 

--- a/src/content_core/cli.py
+++ b/src/content_core/cli.py
@@ -128,10 +128,10 @@ def config():
       crawl4ai_api_url     Crawl4AI Docker API URL (default: none, uses local mode)
       audio_model          Override STT model
       audio_provider       Override STT provider
-    docling_api_key      Docling Serve API key (default: none)
-    docling_api_url      Docling Serve base URL (default: none, uses local Docling if installed)
+        docling_api_key      Docling Serve API key (default: none)
+        docling_api_url      Docling Serve base URL (default: none, uses local Docling if installed)
       docling_output_format  Docling output format (default: markdown)
-    docling_timeout      Docling Serve request timeout in seconds (default: 300)
+        docling_timeout      Docling Serve request timeout in seconds (default: 300)
       document_engine      Document extraction engine (auto, simple, docling)
       firecrawl_api_url    Firecrawl API URL
       firecrawl_proxy      Firecrawl proxy mode: auto, basic, stealth (default: auto)
@@ -154,9 +154,9 @@ def config():
 @config.command("list")
 def config_list_cmd():
     """List all config values from the config file."""
-    from content_core.config import config_list, CONFIG_FILE
+    from content_core.config import config_list_redacted, CONFIG_FILE
 
-    data = config_list()
+    data = config_list_redacted()
     if not data:
         click.echo(
             "No values set. Use 'content-core config set <key> <value>' to configure."

--- a/src/content_core/cli.py
+++ b/src/content_core/cli.py
@@ -9,6 +9,7 @@ from content_core.logging import configure_logging
 
 def _get_version():
     from importlib.metadata import version
+
     return version("content-core")
 
 
@@ -36,9 +37,21 @@ def cli(debug):
     default=None,
     help="Override extraction engine (URL: firecrawl, jina, crawl4ai, simple; Document: docling, simple)",
 )
-@click.option("--formulas", is_flag=True, default=False, help="Enable formula extraction (Docling only)")
-@click.option("--pictures", is_flag=True, default=False, help="Enable image description + chart extraction (Docling only)")
-@click.option("--no-ocr", "no_ocr", is_flag=True, default=False, help="Disable OCR (Docling only)")
+@click.option(
+    "--formulas",
+    is_flag=True,
+    default=False,
+    help="Enable formula extraction (Docling only)",
+)
+@click.option(
+    "--pictures",
+    is_flag=True,
+    default=False,
+    help="Enable image description + chart extraction (Docling only)",
+)
+@click.option(
+    "--no-ocr", "no_ocr", is_flag=True, default=False, help="Disable OCR (Docling only)"
+)
 def extract(source, fmt, engine, formulas, pictures, no_ocr):
     """Extract content from a URL, file path, or text.
 
@@ -48,7 +61,9 @@ def extract(source, fmt, engine, formulas, pictures, no_ocr):
 
     if source is None:
         if sys.stdin.isatty():
-            click.echo("Error: No source provided. Provide a source or pipe input.", err=True)
+            click.echo(
+                "Error: No source provided. Provide a source or pipe input.", err=True
+            )
             sys.exit(1)
         source = sys.stdin.read().strip()
         if not source:
@@ -56,8 +71,14 @@ def extract(source, fmt, engine, formulas, pictures, no_ocr):
             sys.exit(1)
 
     inp = _build_input(source)
-    config = _build_config(inp, engine, formulas=formulas, pictures=pictures, no_ocr=no_ocr)
-    result = asyncio.run(extract_content(url=inp.url, file_path=inp.file_path, content=inp.content, config=config))
+    config = _build_config(
+        inp, engine, formulas=formulas, pictures=pictures, no_ocr=no_ocr
+    )
+    result = asyncio.run(
+        extract_content(
+            url=inp.url, file_path=inp.file_path, content=inp.content, config=config
+        )
+    )
 
     if fmt == "json":
         click.echo(result.model_dump_json(indent=2))
@@ -81,7 +102,10 @@ def summarize(content, context):
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
     if not result:
-        click.echo("Error: Summarization returned no result. Run with --debug for details.", err=True)
+        click.echo(
+            "Error: Summarization returned no result. Run with --debug for details.",
+            err=True,
+        )
         sys.exit(1)
     click.echo(result)
 
@@ -104,7 +128,10 @@ def config():
       crawl4ai_api_url     Crawl4AI Docker API URL (default: none, uses local mode)
       audio_model          Override STT model
       audio_provider       Override STT provider
+    docling_api_key      Docling Serve API key (default: none)
+    docling_api_url      Docling Serve base URL (default: none, uses local Docling if installed)
       docling_output_format  Docling output format (default: markdown)
+    docling_timeout      Docling Serve request timeout in seconds (default: 300)
       document_engine      Document extraction engine (auto, simple, docling)
       firecrawl_api_url    Firecrawl API URL
       firecrawl_proxy      Firecrawl proxy mode: auto, basic, stealth (default: auto)
@@ -131,7 +158,9 @@ def config_list_cmd():
 
     data = config_list()
     if not data:
-        click.echo("No values set. Use 'content-core config set <key> <value>' to configure.")
+        click.echo(
+            "No values set. Use 'content-core config set <key> <value>' to configure."
+        )
         click.echo(f"File: {CONFIG_FILE}")
         click.echo("Run 'content-core config --help' to see available keys.")
         return

--- a/src/content_core/common/exceptions.py
+++ b/src/content_core/common/exceptions.py
@@ -46,6 +46,12 @@ class ExternalServiceError(ContentCoreError):
     pass
 
 
+class DocumentExtractionError(ContentCoreError):
+    """Raised when a document extraction backend fails."""
+
+    pass
+
+
 class RateLimitError(ContentCoreError):
     """Raised when a rate limit is exceeded."""
 

--- a/src/content_core/config.py
+++ b/src/content_core/config.py
@@ -196,7 +196,15 @@ def config_set(key: str, value: str) -> None:
     field = ContentCoreConfig.model_fields[key]
     annotation = field.annotation
     if annotation is int or (hasattr(annotation, "__origin__") and annotation is int):
-        data[key] = int(value)
+        try:
+            coerced = int(value)
+        except ValueError as exc:
+            raise ValueError(f"Invalid integer value for {key}: {value}") from exc
+
+        if key == "docling_timeout" and coerced <= 0:
+            raise ValueError("docling_timeout must be a positive integer")
+
+        data[key] = coerced
     elif annotation is bool:
         data[key] = value.lower() in ("true", "1", "yes")
     elif (
@@ -222,6 +230,19 @@ def config_delete(key: str) -> None:
 def config_list() -> dict:
     """List all config values from the file."""
     return _read_config_file()
+
+
+def redact_config_value(key: str, value: Any) -> Any:
+    """Redact sensitive config values for display purposes."""
+    if key in {"docling_api_key"} and value:
+        return "***"
+    return value
+
+
+def config_list_redacted() -> dict:
+    """List config values with sensitive fields redacted."""
+    data = _read_config_file()
+    return {k: redact_config_value(k, v) for k, v in data.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -253,14 +274,3 @@ def get_firecrawl_api_url() -> str:
     if env_url:
         return env_url
     return get_default_config().firecrawl_api_url
-
-
-def get_docling_api_url() -> str | None:
-    """Return Docling Serve API URL.
-
-    Checks DOCLING_API_URL first, then falls back to config file / default.
-    """
-    env_url = os.environ.get("DOCLING_API_URL")
-    if env_url:
-        return env_url
-    return get_default_config().docling_api_url

--- a/src/content_core/config.py
+++ b/src/content_core/config.py
@@ -5,8 +5,12 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Tuple, Type
 
-from pydantic import Field
-from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+from pydantic import AliasChoices, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 try:
     import tomllib
@@ -21,9 +25,7 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 class TomlFileSettingsSource(PydanticBaseSettingsSource):
     """Read settings from ~/.content-core/config.toml."""
 
-    def get_field_value(
-        self, field: Any, field_name: str
-    ) -> Tuple[Any, str, bool]:
+    def get_field_value(self, field: Any, field_name: str) -> Tuple[Any, str, bool]:
         data = self._load_toml()
         if field_name in data:
             return data[field_name], field_name, False
@@ -88,6 +90,25 @@ class ContentCoreConfig(BaseSettings):
     docling_formulas: bool = False
     docling_vision: bool = False
 
+    # Docling Serve API (remote)
+    docling_api_url: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "docling_api_url",
+            "CCORE_DOCLING_API_URL",
+            "DOCLING_API_URL",
+        ),
+    )
+    docling_api_key: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "docling_api_key",
+            "CCORE_DOCLING_API_KEY",
+            "DOCLING_API_KEY",
+        ),
+    )
+    docling_timeout: int = Field(default=300, gt=0)
+
     @classmethod
     def settings_customise_sources(
         cls,
@@ -125,6 +146,7 @@ def reset_default_config() -> None:
 # ---------------------------------------------------------------------------
 # Config file management (used by CLI `config` subcommands)
 # ---------------------------------------------------------------------------
+
 
 def _read_config_file() -> dict:
     """Read the config file, returning empty dict if missing."""
@@ -164,7 +186,9 @@ def config_set(key: str, value: str) -> None:
     # Validate key exists in ContentCoreConfig
     valid_keys = set(ContentCoreConfig.model_fields.keys())
     if key not in valid_keys:
-        raise ValueError(f"Unknown config key: {key}. Valid keys: {', '.join(sorted(valid_keys))}")
+        raise ValueError(
+            f"Unknown config key: {key}. Valid keys: {', '.join(sorted(valid_keys))}"
+        )
 
     data = _read_config_file()
 
@@ -175,7 +199,10 @@ def config_set(key: str, value: str) -> None:
         data[key] = int(value)
     elif annotation is bool:
         data[key] = value.lower() in ("true", "1", "yes")
-    elif hasattr(annotation, "__origin__") and getattr(annotation, "__origin__", None) is list:
+    elif (
+        hasattr(annotation, "__origin__")
+        and getattr(annotation, "__origin__", None) is list
+    ):
         data[key] = [v.strip() for v in value.split(",")]
     else:
         data[key] = value
@@ -226,3 +253,14 @@ def get_firecrawl_api_url() -> str:
     if env_url:
         return env_url
     return get_default_config().firecrawl_api_url
+
+
+def get_docling_api_url() -> str | None:
+    """Return Docling Serve API URL.
+
+    Checks DOCLING_API_URL first, then falls back to config file / default.
+    """
+    env_url = os.environ.get("DOCLING_API_URL")
+    if env_url:
+        return env_url
+    return get_default_config().docling_api_url

--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -96,7 +96,9 @@ async def _extract_url(url: str, cfg: ContentCoreConfig) -> ExtractionOutput:
         | set(SUPPORTED_EPUB_TYPES)
         | set(SUPPORTED_OFFICE_TYPES)
     )
-    if DOCLING_AVAILABLE:
+    if cfg.document_engine in {"auto", "docling"} and (
+        DOCLING_AVAILABLE or cfg.docling_api_url
+    ):
         downloadable |= set(DOCLING_SUPPORTED)
     downloadable.discard("text/html")  # HTML is treated as web content, not downloaded
 
@@ -125,13 +127,40 @@ def _route_for_mime(mime: str, cfg: ContentCoreConfig) -> str | None:
     "audio", "text") or ``None`` if the type is unsupported.
     """
     engine = cfg.document_engine
-    docling_enabled = bool(cfg.docling_api_url) or DOCLING_AVAILABLE
-    if engine == "docling" or (
-        engine == "auto" and docling_enabled and mime in DOCLING_SUPPORTED
+
+    # Remote Docling Serve must only handle Docling-supported document MIME types.
+    if (
+        cfg.document_engine in {"auto", "docling"}
+        and cfg.docling_api_url
+        and mime in DOCLING_SUPPORTED
     ):
-        if (cfg.docling_api_url or DOCLING_AVAILABLE) and extract_docling is not None:
+        if extract_docling is not None:
             return "docling"
 
+    # Local Docling behavior (auto/docling engine) remains unchanged.
+    if engine == "docling" or (
+        engine == "auto" and DOCLING_AVAILABLE and mime in DOCLING_SUPPORTED
+    ):
+        if DOCLING_AVAILABLE and extract_docling is not None:
+            return "docling"
+
+    if mime in SUPPORTED_PDF_TYPES:
+        return "pdf"
+    if mime in SUPPORTED_EPUB_TYPES:
+        return "epub"
+    if mime in SUPPORTED_OFFICE_TYPES:
+        return "office"
+    if mime.startswith("video/"):
+        return "video"
+    if mime.startswith("audio/"):
+        return "audio"
+    if mime == "text/plain":
+        return "text"
+    return None
+
+
+def _route_standard_for_mime(mime: str) -> str | None:
+    """Return non-Docling processor route for a MIME type."""
     if mime in SUPPORTED_PDF_TYPES:
         return "pdf"
     if mime in SUPPORTED_EPUB_TYPES:
@@ -215,12 +244,26 @@ async def _extract_file(
         # Docling routing (if enabled and supported)
         if route == "docling":
             used_docling = True
-            result = await extract_docling(path, cfg)
-            if not result.title:
-                result.title = os.path.basename(path)
-            result.identified_type = mime
-            result.source_type = "file"
-            return result
+            try:
+                result = await extract_docling(path, cfg)
+            except ImportError as exc:
+                if cfg.docling_api_url or cfg.document_engine == "docling":
+                    raise
+                logger.warning(
+                    "Docling import failed at runtime; falling back to standard processor."
+                )
+                used_docling = False
+                route = _route_standard_for_mime(mime)
+                if route is None:
+                    raise UnsupportedTypeException(
+                        f"Unsupported file type: {mime}"
+                    ) from exc
+            else:
+                if not result.title:
+                    result.title = os.path.basename(path)
+                result.identified_type = mime
+                result.source_type = "file"
+                return result
 
         # Standard processors
         if route == "pdf":

--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -99,7 +99,7 @@ async def _extract_url(url: str, cfg: ContentCoreConfig) -> ExtractionOutput:
         | set(SUPPORTED_OFFICE_TYPES)
     )
     if cfg.document_engine in {"auto", "docling"} and (
-        is_docling_capable() or cfg.docling_api_url
+        cfg.docling_api_url or is_docling_capable()
     ):
         downloadable |= set(DOCLING_SUPPORTED)
     downloadable.discard("text/html")  # HTML is treated as web content, not downloaded

--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -30,14 +30,16 @@ from content_core.processors.url.youtube import extract_youtube
 # Optional docling
 try:
     from content_core.processors.document.docling import (
-        DOCLING_AVAILABLE,
         DOCLING_SUPPORTED,
         extract_docling,
+        is_docling_capable,
     )
 except ImportError:
-    DOCLING_AVAILABLE = False
     DOCLING_SUPPORTED = set()
     extract_docling = None  # type: ignore
+
+    def is_docling_capable() -> bool:
+        return False
 
 
 async def extract_content(
@@ -97,7 +99,7 @@ async def _extract_url(url: str, cfg: ContentCoreConfig) -> ExtractionOutput:
         | set(SUPPORTED_OFFICE_TYPES)
     )
     if cfg.document_engine in {"auto", "docling"} and (
-        DOCLING_AVAILABLE or cfg.docling_api_url
+        is_docling_capable() or cfg.docling_api_url
     ):
         downloadable |= set(DOCLING_SUPPORTED)
     downloadable.discard("text/html")  # HTML is treated as web content, not downloaded
@@ -139,24 +141,12 @@ def _route_for_mime(mime: str, cfg: ContentCoreConfig) -> str | None:
 
     # Local Docling behavior (auto/docling engine) remains unchanged.
     if engine == "docling" or (
-        engine == "auto" and DOCLING_AVAILABLE and mime in DOCLING_SUPPORTED
+        engine == "auto" and is_docling_capable() and mime in DOCLING_SUPPORTED
     ):
-        if DOCLING_AVAILABLE and extract_docling is not None:
+        if is_docling_capable() and extract_docling is not None:
             return "docling"
 
-    if mime in SUPPORTED_PDF_TYPES:
-        return "pdf"
-    if mime in SUPPORTED_EPUB_TYPES:
-        return "epub"
-    if mime in SUPPORTED_OFFICE_TYPES:
-        return "office"
-    if mime.startswith("video/"):
-        return "video"
-    if mime.startswith("audio/"):
-        return "audio"
-    if mime == "text/plain":
-        return "text"
-    return None
+    return _route_standard_for_mime(mime)
 
 
 def _route_standard_for_mime(mime: str) -> str | None:

--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -17,7 +17,10 @@ from content_core.common.state import ExtractionOutput, FileSupport
 from content_core.processors.media.audio import transcribe_audio
 from content_core.processors.document import SUPPORTED_OFFICE_TYPES, extract_office
 from content_core.processors.document.pdf import SUPPORTED_PDF_TYPES, extract_pdf_file
-from content_core.processors.document.epub import SUPPORTED_EPUB_TYPES, extract_epub_file
+from content_core.processors.document.epub import (
+    SUPPORTED_EPUB_TYPES,
+    extract_epub_file,
+)
 from content_core.processors.text import extract_text_file, process_text
 from content_core.processors.url import detect_remote_mime, extract_from_url
 from content_core.processors.media.video import extract_video
@@ -80,13 +83,19 @@ async def _extract_url(url: str, cfg: ContentCoreConfig) -> ExtractionOutput:
         result = await extract_reddit(url, cfg)
         if result and result.content:
             return result
-        logger.debug("Reddit JSON extraction failed, falling back to normal URL extraction")
+        logger.debug(
+            "Reddit JSON extraction failed, falling back to normal URL extraction"
+        )
 
     # Check MIME type via HEAD request
     mime = await detect_remote_mime(url)
 
     # Downloadable file types (PDFs, Office docs, etc served over HTTP)
-    downloadable = set(SUPPORTED_PDF_TYPES) | set(SUPPORTED_EPUB_TYPES) | set(SUPPORTED_OFFICE_TYPES)
+    downloadable = (
+        set(SUPPORTED_PDF_TYPES)
+        | set(SUPPORTED_EPUB_TYPES)
+        | set(SUPPORTED_OFFICE_TYPES)
+    )
     if DOCLING_AVAILABLE:
         downloadable |= set(DOCLING_SUPPORTED)
     downloadable.discard("text/html")  # HTML is treated as web content, not downloaded
@@ -116,10 +125,11 @@ def _route_for_mime(mime: str, cfg: ContentCoreConfig) -> str | None:
     "audio", "text") or ``None`` if the type is unsupported.
     """
     engine = cfg.document_engine
+    docling_enabled = bool(cfg.docling_api_url) or DOCLING_AVAILABLE
     if engine == "docling" or (
-        engine == "auto" and DOCLING_AVAILABLE and mime in DOCLING_SUPPORTED
+        engine == "auto" and docling_enabled and mime in DOCLING_SUPPORTED
     ):
-        if DOCLING_AVAILABLE and extract_docling is not None:
+        if (cfg.docling_api_url or DOCLING_AVAILABLE) and extract_docling is not None:
             return "docling"
 
     if mime in SUPPORTED_PDF_TYPES:
@@ -228,7 +238,9 @@ async def _extract_file(
         else:
             raise UnsupportedTypeException(f"Unsupported file type: {mime}")
 
-        if not used_docling and (cfg.docling_formulas or cfg.docling_vision or not cfg.docling_ocr):
+        if not used_docling and (
+            cfg.docling_formulas or cfg.docling_vision or not cfg.docling_ocr
+        ):
             logger.warning(
                 "Docling enrichment flags (docling_formulas, docling_vision, docling_ocr) "
                 "are only applied when document_engine='docling'. "

--- a/src/content_core/processors/document/docling.py
+++ b/src/content_core/processors/document/docling.py
@@ -2,35 +2,36 @@
 Docling-based document extraction processor.
 """
 
+from __future__ import annotations
+
+import asyncio
+from importlib.util import find_spec
+import json
+from pathlib import Path
+
+import aiohttp
+
+from content_core.common.exceptions import DocumentExtractionError
 from content_core.config import ContentCoreConfig
 from content_core.common.state import ExtractionOutput
 
-DOCLING_AVAILABLE = False
-try:
+DOCLING_AVAILABLE = find_spec("docling") is not None
+
+
+def _load_docling_classes():
+    """Import local Docling lazily so module import stays cheap."""
+    if not DOCLING_AVAILABLE:
+        raise ImportError(
+            "Docling not installed. Install with: pip install content-core[docling] "
+            "or use CCORE_DOCUMENT_ENGINE=simple to skip docling."
+        )
+
     from docling.datamodel.base_models import InputFormat
     from docling.datamodel.pipeline_options import PdfPipelineOptions
     from docling.document_converter import DocumentConverter, PdfFormatOption
 
-    DOCLING_AVAILABLE = True
-except ImportError:
-    InputFormat = None  # type: ignore
-    PdfPipelineOptions = None  # type: ignore
-    PdfFormatOption = None  # type: ignore
+    return InputFormat, PdfPipelineOptions, DocumentConverter, PdfFormatOption
 
-    class DocumentConverter:  # type: ignore[no-redef]
-        """Stub when docling is not installed."""
-
-        def __init__(self, **kwargs):
-            raise ImportError(
-                "Docling not installed. Install with: pip install content-core[docling] "
-                "or use CCORE_DOCUMENT_ENGINE=simple to skip docling."
-            )
-
-        def convert(self, source: str):
-            raise ImportError(
-                "Docling not installed. Install with: pip install content-core[docling] "
-                "or use CCORE_DOCUMENT_ENGINE=simple to skip docling."
-            )
 
 # Supported MIME types for Docling extraction
 DOCLING_SUPPORTED = {
@@ -50,9 +51,166 @@ DOCLING_SUPPORTED = {
 }
 
 
-async def extract_docling(source: str, config: ContentCoreConfig) -> ExtractionOutput:
-    """Extract content using Docling."""
-    if DOCLING_AVAILABLE and PdfPipelineOptions is not None:
+def _normalize_docling_api_url(api_url: str) -> str:
+    """Normalize Docling Serve base URL to a stable /v1 root."""
+    normalized = api_url.strip().rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    if normalized.endswith("/v1/convert"):
+        return normalized[: -len("/convert")]
+    if normalized.endswith("/convert/file"):
+        return normalized[: -len("/convert/file")]
+    if normalized.endswith("/convert/source"):
+        return normalized[: -len("/convert/source")]
+    return f"{normalized}/v1"
+
+
+def _docling_file_endpoint(api_url: str) -> str:
+    return f"{_normalize_docling_api_url(api_url)}/convert/file"
+
+
+def _docling_headers(config: ContentCoreConfig) -> dict[str, str]:
+    headers = {"accept": "application/json"}
+    if config.docling_api_key:
+        headers["X-Api-Key"] = config.docling_api_key
+    return headers
+
+
+def _docling_form_fields(config: ContentCoreConfig) -> list[tuple[str, str]]:
+    fields: list[tuple[str, str]] = [
+        ("to_formats", "md"),
+        ("do_ocr", "true" if config.docling_ocr else "false"),
+        ("abort_on_error", "true"),
+    ]
+    if config.docling_formulas:
+        fields.append(("do_formula_enrichment", "true"))
+    if config.docling_vision:
+        fields.append(("do_picture_description", "true"))
+        fields.append(("do_chart_extraction", "true"))
+    return fields
+
+
+def _extract_remote_markdown(payload: dict) -> str:
+    document = payload.get("document")
+    if not isinstance(document, dict):
+        raise DocumentExtractionError(
+            "Docling Serve returned an unexpected response: missing 'document' object."
+        )
+
+    failure = payload.get("failure") or document.get("failure")
+    if failure:
+        raise DocumentExtractionError(f"Docling Serve conversion failed: {failure}")
+
+    errors = payload.get("errors") or document.get("errors")
+    if errors:
+        raise DocumentExtractionError(f"Docling Serve conversion failed: {errors}")
+
+    markdown = document.get("md_content")
+    if isinstance(markdown, str) and markdown.strip():
+        return markdown
+
+    status = document.get("status")
+    if status and str(status).lower() not in {"success", "succeeded", "ok"}:
+        raise DocumentExtractionError(
+            f"Docling Serve conversion failed with status: {status}"
+        )
+
+    raise DocumentExtractionError(
+        "Docling Serve returned success but no markdown content in 'document.md_content'."
+    )
+
+
+async def _extract_docling_remote(
+    source: str, config: ContentCoreConfig
+) -> ExtractionOutput:
+    if not config.docling_api_url:
+        raise DocumentExtractionError("Docling Serve API URL is not configured.")
+    if config.docling_output_format != "markdown":
+        raise DocumentExtractionError(
+            "External Docling Serve extraction currently supports only docling_output_format='markdown'."
+        )
+
+    file_path = Path(source)
+    endpoint = _docling_file_endpoint(config.docling_api_url)
+    timeout = aiohttp.ClientTimeout(total=config.docling_timeout)
+    form = aiohttp.FormData()
+    for key, value in _docling_form_fields(config):
+        form.add_field(key, value)
+    form.add_field(
+        "files",
+        file_path.read_bytes(),
+        filename=file_path.name,
+        content_type="application/octet-stream",
+    )
+
+    try:
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            async with session.post(
+                endpoint,
+                data=form,
+                headers=_docling_headers(config),
+                timeout=timeout,
+            ) as response:
+                body_text = await response.text()
+                if response.status < 200 or response.status >= 300:
+                    detail = body_text.strip()
+                    try:
+                        error_payload = json.loads(body_text) if body_text else {}
+                    except json.JSONDecodeError:
+                        error_payload = None
+                    if isinstance(error_payload, dict):
+                        detail = str(error_payload.get("detail") or detail)
+                    raise DocumentExtractionError(
+                        f"Docling Serve request failed with HTTP {response.status}: {detail or 'no error details returned'}"
+                    )
+    except aiohttp.ClientConnectorError as exc:
+        raise DocumentExtractionError(
+            f"Failed to connect to Docling Serve at {endpoint}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise DocumentExtractionError(
+            f"Failed to reach Docling Serve at {endpoint}: {exc}"
+        ) from exc
+    except aiohttp.ClientError as exc:
+        raise DocumentExtractionError(f"Docling Serve request failed: {exc}") from exc
+    except asyncio.TimeoutError as exc:
+        raise DocumentExtractionError(
+            (
+                "Docling Serve request timed out "
+                f"after {config.docling_timeout} seconds. "
+                "Check network connectivity or increase docling_timeout."
+            )
+        ) from exc
+
+    try:
+        payload = json.loads(body_text)
+    except json.JSONDecodeError as exc:
+        raise DocumentExtractionError(
+            "Docling Serve returned invalid JSON for file conversion."
+        ) from exc
+
+    return ExtractionOutput(
+        content=_extract_remote_markdown(payload),
+        source_type="file",
+        identified_type="",
+        metadata={
+            "docling_format": "markdown",
+            "docling_backend": "remote",
+            "docling_api_url": _normalize_docling_api_url(config.docling_api_url),
+        },
+    )
+
+
+async def _extract_docling_local(
+    source: str, config: ContentCoreConfig
+) -> ExtractionOutput:
+    if DOCLING_AVAILABLE:
+        (
+            InputFormat,
+            PdfPipelineOptions,
+            DocumentConverter,
+            PdfFormatOption,
+        ) = _load_docling_classes()
         pipeline_options = PdfPipelineOptions(
             do_ocr=config.docling_ocr,
             do_formula_enrichment=config.docling_formulas,
@@ -65,10 +223,7 @@ async def extract_docling(source: str, config: ContentCoreConfig) -> ExtractionO
             }
         )
     else:
-        converter = DocumentConverter()
-
-    if not source:
-        raise ValueError("No input provided for Docling extraction.")
+        _load_docling_classes()
 
     result = converter.convert(source)
     doc = result.document
@@ -85,5 +240,16 @@ async def extract_docling(source: str, config: ContentCoreConfig) -> ExtractionO
         content=output,
         source_type="file",
         identified_type="",
-        metadata={"docling_format": fmt},
+        metadata={"docling_format": fmt, "docling_backend": "local"},
     )
+
+
+async def extract_docling(source: str, config: ContentCoreConfig) -> ExtractionOutput:
+    """Extract content using Docling."""
+    if not source:
+        raise ValueError("No input provided for Docling extraction.")
+
+    if config.docling_api_url:
+        return await _extract_docling_remote(source, config)
+
+    return await _extract_docling_local(source, config)

--- a/src/content_core/processors/document/docling.py
+++ b/src/content_core/processors/document/docling.py
@@ -15,9 +15,6 @@ from content_core.common.exceptions import DocumentExtractionError
 from content_core.config import ContentCoreConfig
 from content_core.common.state import ExtractionOutput
 
-DOCLING_AVAILABLE = find_spec("docling") is not None
-
-
 _DOCLING_CAPABLE: bool | None = None
 
 

--- a/src/content_core/processors/document/docling.py
+++ b/src/content_core/processors/document/docling.py
@@ -18,9 +18,40 @@ from content_core.common.state import ExtractionOutput
 DOCLING_AVAILABLE = find_spec("docling") is not None
 
 
+_DOCLING_CAPABLE: bool | None = None
+
+
+def is_docling_capable() -> bool:
+    """Return whether local Docling is actually importable.
+
+    Checks once (cached) by attempting the real imports.
+    """
+    global _DOCLING_CAPABLE
+    if _DOCLING_CAPABLE is not None:
+        return _DOCLING_CAPABLE
+
+    if find_spec("docling") is None:
+        _DOCLING_CAPABLE = False
+        return False
+
+    try:
+        _load_docling_classes()
+        _DOCLING_CAPABLE = True
+        return True
+    except Exception:
+        _DOCLING_CAPABLE = False
+        return False
+
+
+def _reset_docling_capable() -> None:
+    """Reset the cached capability flag. For testing only."""
+    global _DOCLING_CAPABLE
+    _DOCLING_CAPABLE = None
+
+
 def _load_docling_classes():
     """Import local Docling lazily so module import stays cheap."""
-    if not DOCLING_AVAILABLE:
+    if find_spec("docling") is None:
         raise ImportError(
             "Docling not installed. Install with: pip install content-core[docling] "
             "or use CCORE_DOCUMENT_ENGINE=simple to skip docling."
@@ -215,26 +246,23 @@ async def _extract_docling_remote(
 async def _extract_docling_local(
     source: str, config: ContentCoreConfig
 ) -> ExtractionOutput:
-    if DOCLING_AVAILABLE:
-        (
-            InputFormat,
-            PdfPipelineOptions,
-            DocumentConverter,
-            PdfFormatOption,
-        ) = _load_docling_classes()
-        pipeline_options = PdfPipelineOptions(
-            do_ocr=config.docling_ocr,
-            do_formula_enrichment=config.docling_formulas,
-            do_picture_description=config.docling_vision,
-            do_chart_extraction=config.docling_vision,
-        )
-        converter = DocumentConverter(
-            format_options={
-                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
-            }
-        )
-    else:
-        _load_docling_classes()
+    (
+        InputFormat,
+        PdfPipelineOptions,
+        DocumentConverter,
+        PdfFormatOption,
+    ) = _load_docling_classes()
+    pipeline_options = PdfPipelineOptions(
+        do_ocr=config.docling_ocr,
+        do_formula_enrichment=config.docling_formulas,
+        do_picture_description=config.docling_vision,
+        do_chart_extraction=config.docling_vision,
+    )
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+        }
+    )
 
     result = converter.convert(source)
     doc = result.document

--- a/src/content_core/processors/document/docling.py
+++ b/src/content_core/processors/document/docling.py
@@ -26,9 +26,15 @@ def _load_docling_classes():
             "or use CCORE_DOCUMENT_ENGINE=simple to skip docling."
         )
 
-    from docling.datamodel.base_models import InputFormat
-    from docling.datamodel.pipeline_options import PdfPipelineOptions
-    from docling.document_converter import DocumentConverter, PdfFormatOption
+    try:
+        from docling.datamodel.base_models import InputFormat
+        from docling.datamodel.pipeline_options import PdfPipelineOptions
+        from docling.document_converter import DocumentConverter, PdfFormatOption
+    except Exception as exc:
+        raise ImportError(
+            "Docling package was found but failed to import. "
+            "Reinstall content-core[docling] or use CCORE_DOCUMENT_ENGINE=simple."
+        ) from exc
 
     return InputFormat, PdfPipelineOptions, DocumentConverter, PdfFormatOption
 
@@ -163,6 +169,14 @@ async def _extract_docling_remote(
                     raise DocumentExtractionError(
                         f"Docling Serve request failed with HTTP {response.status}: {detail or 'no error details returned'}"
                     )
+    except asyncio.TimeoutError as exc:
+        raise DocumentExtractionError(
+            (
+                "Docling Serve request timed out "
+                f"after {config.docling_timeout} seconds. "
+                "Check network connectivity or increase docling_timeout."
+            )
+        ) from exc
     except aiohttp.ClientConnectorError as exc:
         raise DocumentExtractionError(
             f"Failed to connect to Docling Serve at {endpoint}: {exc}"
@@ -173,14 +187,6 @@ async def _extract_docling_remote(
         ) from exc
     except aiohttp.ClientError as exc:
         raise DocumentExtractionError(f"Docling Serve request failed: {exc}") from exc
-    except asyncio.TimeoutError as exc:
-        raise DocumentExtractionError(
-            (
-                "Docling Serve request timed out "
-                f"after {config.docling_timeout} seconds. "
-                "Check network connectivity or increase docling_timeout."
-            )
-        ) from exc
 
     try:
         payload = json.loads(body_text)
@@ -188,6 +194,11 @@ async def _extract_docling_remote(
         raise DocumentExtractionError(
             "Docling Serve returned invalid JSON for file conversion."
         ) from exc
+
+    if not isinstance(payload, dict):
+        raise DocumentExtractionError(
+            "Docling Serve returned an unexpected JSON payload type; expected an object."
+        )
 
     return ExtractionOutput(
         content=_extract_remote_markdown(payload),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -97,9 +97,7 @@ class TestExtractCommand:
             new_callable=AsyncMock,
             return_value=ExtractionOutput(content="ok"),
         ) as mock_extract:
-            result = runner.invoke(
-                cli, ["extract", "--engine", "docling", str(f)]
-            )
+            result = runner.invoke(cli, ["extract", "--engine", "docling", str(f)])
             assert result.exit_code == 0
             _, kwargs = mock_extract.call_args
             assert kwargs["config"] is not None
@@ -218,6 +216,18 @@ class TestConfigCommands:
         result = runner.invoke(cli, ["config", "list"])
         assert result.exit_code == 0
         assert "llm_provider = anthropic" in result.output
+
+    def test_config_list_redacts_docling_api_key(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["config", "set", "docling_api_key", "secret-token"]
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(cli, ["config", "list"])
+        assert result.exit_code == 0
+        assert "docling_api_key = ***" in result.output
+        assert "secret-token" not in result.output
 
     def test_config_set_invalid_key(self):
         runner = CliRunner()

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -81,6 +81,23 @@ class TestConfigSet:
         with pytest.raises(ValueError, match="Unknown config key"):
             config_set("nonexistent_key", "value")
 
+    def test_set_docling_timeout_zero_rejected_and_not_persisted(self, config_dir):
+        with pytest.raises(ValueError, match="positive integer"):
+            config_set("docling_timeout", "0")
+        assert "docling_timeout" not in config_list()
+
+    def test_set_docling_timeout_negative_rejected_and_not_persisted(self, config_dir):
+        with pytest.raises(ValueError, match="positive integer"):
+            config_set("docling_timeout", "-1")
+        assert "docling_timeout" not in config_list()
+
+    def test_set_docling_timeout_non_integer_rejected_and_not_persisted(
+        self, config_dir
+    ):
+        with pytest.raises(ValueError, match="Invalid integer value"):
+            config_set("docling_timeout", "abc")
+        assert "docling_timeout" not in config_list()
+
     def test_set_overwrites_existing(self, config_dir):
         config_set("llm_provider", "openai")
         config_set("llm_provider", "anthropic")

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -68,6 +68,15 @@ class TestConfigSet:
         assert data["docling_vision"] is True
         assert data["docling_ocr"] is False
 
+    def test_set_docling_remote_settings(self, config_dir):
+        config_set("docling_api_url", "https://docling.example")
+        config_set("docling_api_key", "secret-token")
+        config_set("docling_timeout", "120")
+        data = config_list()
+        assert data["docling_api_url"] == "https://docling.example"
+        assert data["docling_api_key"] == "secret-token"
+        assert data["docling_timeout"] == 120
+
     def test_set_invalid_key_raises(self, config_dir):
         with pytest.raises(ValueError, match="Unknown config key"):
             config_set("nonexistent_key", "value")

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -163,6 +163,11 @@ class TestEnvVarOverride:
         cfg = ContentCoreConfig()
         assert cfg.docling_api_key == "secret-token"
 
+    def test_docling_api_key_from_prefixed_env(self, monkeypatch):
+        monkeypatch.setenv("CCORE_DOCLING_API_KEY", "secret-token")
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_key == "secret-token"
+
     def test_docling_timeout_from_prefixed_env(self, monkeypatch):
         monkeypatch.setenv("CCORE_DOCLING_TIMEOUT", "120")
         cfg = ContentCoreConfig()

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -38,6 +38,8 @@ def _clean_env(monkeypatch):
     for key in list(os.environ):
         if key.startswith("CCORE_"):
             monkeypatch.delenv(key, raising=False)
+    for key in ("DOCLING_API_URL", "DOCLING_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
 
 
 class TestDefaults:
@@ -99,6 +101,18 @@ class TestDefaults:
         cfg = ContentCoreConfig()
         assert cfg.docling_output_format == "markdown"
 
+    def test_docling_api_url_default(self):
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_url is None
+
+    def test_docling_api_key_default(self):
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_key is None
+
+    def test_docling_timeout_default(self):
+        cfg = ContentCoreConfig()
+        assert cfg.docling_timeout == 300
+
 
 class TestConstructorOverride:
     """Verify constructor arguments override defaults."""
@@ -133,6 +147,27 @@ class TestEnvVarOverride:
         monkeypatch.setenv("CCORE_LLM_MODEL", "claude-sonnet")
         cfg = ContentCoreConfig()
         assert cfg.llm_model == "claude-sonnet"
+
+    def test_docling_api_url_from_standard_env(self, monkeypatch):
+        monkeypatch.setenv("DOCLING_API_URL", "https://docling.example")
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_url == "https://docling.example"
+
+    def test_docling_api_url_from_prefixed_env(self, monkeypatch):
+        monkeypatch.setenv("CCORE_DOCLING_API_URL", "https://docling.example")
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_url == "https://docling.example"
+
+    def test_docling_api_key_from_standard_env(self, monkeypatch):
+        monkeypatch.setenv("DOCLING_API_KEY", "secret-token")
+        cfg = ContentCoreConfig()
+        assert cfg.docling_api_key == "secret-token"
+
+    def test_docling_timeout_from_prefixed_env(self, monkeypatch):
+        monkeypatch.setenv("CCORE_DOCLING_TIMEOUT", "120")
+        cfg = ContentCoreConfig()
+        assert cfg.docling_timeout == 120
+
 
 class TestEnvVarListField:
     """Verify list fields can be set via environment variables."""
@@ -175,6 +210,11 @@ class TestPriority:
         monkeypatch.setenv("CCORE_LLM_MODEL", "from-env")
         cfg = ContentCoreConfig(llm_model="from-constructor")
         assert cfg.llm_model == "from-constructor"
+
+    def test_constructor_beats_docling_standard_env(self, monkeypatch):
+        monkeypatch.setenv("DOCLING_API_URL", "https://from-env.example")
+        cfg = ContentCoreConfig(docling_api_url="https://from-constructor.example")
+        assert cfg.docling_api_url == "https://from-constructor.example"
 
 
 class TestSingleton:

--- a/tests/unit/test_docling_extraction.py
+++ b/tests/unit/test_docling_extraction.py
@@ -15,6 +15,8 @@ from content_core.processors.document.docling import (
     _docling_headers,
     _normalize_docling_api_url,
     extract_docling,
+    is_docling_capable,
+    _reset_docling_capable,
 )
 
 
@@ -187,8 +189,6 @@ class TestExtractDocling:
         mock_input_format = MagicMock()
         mock_document_converter_cls = MagicMock()
         with patch(
-            "content_core.processors.document.docling.DOCLING_AVAILABLE", True
-        ), patch(
             "content_core.processors.document.docling._load_docling_classes",
             return_value=(
                 mock_input_format,
@@ -221,8 +221,6 @@ class TestExtractDocling:
         mock_input_format = MagicMock()
         mock_document_converter_cls = MagicMock()
         with patch(
-            "content_core.processors.document.docling.DOCLING_AVAILABLE", True
-        ), patch(
             "content_core.processors.document.docling._load_docling_classes",
             return_value=(
                 mock_input_format,
@@ -279,6 +277,44 @@ class TestExtractDocling:
         assert result is local_result
         mock_local.assert_awaited_once_with(str(source), config)
         mock_remote.assert_not_called()
+
+
+class TestDoclingCapability:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        _reset_docling_capable()
+        yield
+        _reset_docling_capable()
+
+    def test_false_when_find_spec_returns_none(self):
+        with patch(
+            "content_core.processors.document.docling.find_spec",
+            return_value=None,
+        ):
+            assert is_docling_capable() is False
+
+    def test_false_when_import_fails_after_find_spec_succeeds(self):
+        with patch(
+            "content_core.processors.document.docling.find_spec",
+            return_value=MagicMock(),
+        ), patch(
+            "content_core.processors.document.docling._load_docling_classes",
+            side_effect=ImportError("broken docling"),
+        ):
+            assert is_docling_capable() is False
+
+    def test_caches_result(self):
+        with patch(
+            "content_core.processors.document.docling.find_spec",
+            return_value=None,
+        ):
+            assert is_docling_capable() is False
+            # Second call should not re-check
+            with patch(
+                "content_core.processors.document.docling.find_spec",
+                side_effect=RuntimeError("should not be called"),
+            ):
+                assert is_docling_capable() is False
 
 
 class TestDoclingServeHelpers:

--- a/tests/unit/test_docling_extraction.py
+++ b/tests/unit/test_docling_extraction.py
@@ -1,11 +1,55 @@
 """Unit tests for content_core.processors.document.docling."""
 
+import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
+import aiohttp
 import pytest
 
 from content_core.config import ContentCoreConfig
-from content_core.processors.document.docling import extract_docling
+from content_core.common.exceptions import DocumentExtractionError
+from content_core.processors.document.docling import (
+    _docling_file_endpoint,
+    _docling_form_fields,
+    _docling_headers,
+    _normalize_docling_api_url,
+    extract_docling,
+)
+
+
+class FakeResponse:
+    def __init__(self, *, status=200, body=None):
+        self.status = status
+        self._body = body if body is not None else "{}"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._body
+
+
+class FakeSession:
+    def __init__(self, *, response=None, exc=None):
+        self.response = response
+        self.exc = exc
+        self.post_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.post_calls.append((args, kwargs))
+        if self.exc is not None:
+            raise self.exc
+        return self.response
 
 
 @pytest.fixture
@@ -30,8 +74,13 @@ class TestExtractDocling:
     async def test_markdown_output(self, mock_converter):
         config = ContentCoreConfig(docling_output_format="markdown")
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             result = await extract_docling("/fake/doc.pdf", config)
             assert result.content == "# Markdown Content\n\nSome text"
@@ -41,8 +90,13 @@ class TestExtractDocling:
     async def test_html_output(self, mock_converter):
         config = ContentCoreConfig(docling_output_format="html")
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             result = await extract_docling("/fake/doc.pdf", config)
             assert "<h1>" in result.content
@@ -51,8 +105,13 @@ class TestExtractDocling:
     async def test_json_output(self, mock_converter):
         config = ContentCoreConfig(docling_output_format="json")
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             result = await extract_docling("/fake/doc.pdf", config)
             assert "JSON Content" in result.content
@@ -61,8 +120,13 @@ class TestExtractDocling:
     async def test_default_format_is_markdown(self, mock_converter):
         config = ContentCoreConfig()  # defaults to "markdown"
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             result = await extract_docling("/fake/doc.pdf", config)
             mock_converter.convert.assert_called_once_with("/fake/doc.pdf")
@@ -71,8 +135,13 @@ class TestExtractDocling:
     async def test_returns_extraction_output(self, mock_converter):
         config = ContentCoreConfig()
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             result = await extract_docling("/fake/doc.pdf", config)
             from content_core.common.state import ExtractionOutput
@@ -82,8 +151,13 @@ class TestExtractDocling:
     async def test_empty_source_raises_value_error(self, mock_converter):
         config = ContentCoreConfig()
         with patch(
-            "content_core.processors.document.docling.DocumentConverter",
-            return_value=mock_converter,
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(return_value=mock_converter),
+                MagicMock(),
+            ),
         ):
             with pytest.raises(ValueError, match="No input provided"):
                 await extract_docling("", config)
@@ -111,27 +185,30 @@ class TestExtractDocling:
         mock_pipeline_options_cls = MagicMock()
         mock_pdf_format_option_cls = MagicMock()
         mock_input_format = MagicMock()
+        mock_document_converter_cls = MagicMock()
         with patch(
-            "content_core.processors.document.docling.DocumentConverter"
-        ) as MockConverter, patch(
             "content_core.processors.document.docling.DOCLING_AVAILABLE", True
         ), patch(
-            "content_core.processors.document.docling.PdfPipelineOptions", mock_pipeline_options_cls
-        ), patch(
-            "content_core.processors.document.docling.PdfFormatOption", mock_pdf_format_option_cls
-        ), patch(
-            "content_core.processors.document.docling.InputFormat", mock_input_format
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                mock_input_format,
+                mock_pipeline_options_cls,
+                mock_document_converter_cls,
+                mock_pdf_format_option_cls,
+            ),
         ):
-            MockConverter.return_value.convert.return_value = mock_result
+            mock_document_converter_cls.return_value.convert.return_value = mock_result
             await extract_docling("/fake/doc.pdf", config)
             # Verify DocumentConverter was called with format_options
-            call_kwargs = MockConverter.call_args[1]
+            call_kwargs = mock_document_converter_cls.call_args[1]
             assert "format_options" in call_kwargs
             # Verify pipeline option values match config
             pipeline_call_kwargs = mock_pipeline_options_cls.call_args[1]
             assert pipeline_call_kwargs["do_ocr"] == config.docling_ocr
             assert pipeline_call_kwargs["do_formula_enrichment"] is True
-            assert pipeline_call_kwargs["do_picture_description"] == config.docling_vision
+            assert (
+                pipeline_call_kwargs["do_picture_description"] == config.docling_vision
+            )
             assert pipeline_call_kwargs["do_chart_extraction"] == config.docling_vision
 
     async def test_vision_flag_passed_to_pipeline(self):
@@ -142,24 +219,262 @@ class TestExtractDocling:
         mock_pipeline_options_cls = MagicMock()
         mock_pdf_format_option_cls = MagicMock()
         mock_input_format = MagicMock()
+        mock_document_converter_cls = MagicMock()
         with patch(
-            "content_core.processors.document.docling.DocumentConverter"
-        ) as MockConverter, patch(
             "content_core.processors.document.docling.DOCLING_AVAILABLE", True
         ), patch(
-            "content_core.processors.document.docling.PdfPipelineOptions", mock_pipeline_options_cls
-        ), patch(
-            "content_core.processors.document.docling.PdfFormatOption", mock_pdf_format_option_cls
-        ), patch(
-            "content_core.processors.document.docling.InputFormat", mock_input_format
+            "content_core.processors.document.docling._load_docling_classes",
+            return_value=(
+                mock_input_format,
+                mock_pipeline_options_cls,
+                mock_document_converter_cls,
+                mock_pdf_format_option_cls,
+            ),
         ):
-            MockConverter.return_value.convert.return_value = mock_result
+            mock_document_converter_cls.return_value.convert.return_value = mock_result
             await extract_docling("/fake/doc.pdf", config)
-            call_kwargs = MockConverter.call_args[1]
+            call_kwargs = mock_document_converter_cls.call_args[1]
             assert "format_options" in call_kwargs
             # Verify pipeline option values match config
             pipeline_call_kwargs = mock_pipeline_options_cls.call_args[1]
             assert pipeline_call_kwargs["do_ocr"] == config.docling_ocr
-            assert pipeline_call_kwargs["do_formula_enrichment"] == config.docling_formulas
+            assert (
+                pipeline_call_kwargs["do_formula_enrichment"] == config.docling_formulas
+            )
             assert pipeline_call_kwargs["do_picture_description"] is True
             assert pipeline_call_kwargs["do_chart_extraction"] is True
+
+    async def test_remote_precedence_over_local(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+
+        remote_result = MagicMock()
+        with patch(
+            "content_core.processors.document.docling._extract_docling_remote",
+            return_value=remote_result,
+        ) as mock_remote, patch(
+            "content_core.processors.document.docling._extract_docling_local",
+        ) as mock_local:
+            result = await extract_docling(str(source), config)
+
+        assert result is remote_result
+        mock_remote.assert_awaited_once_with(str(source), config)
+        mock_local.assert_not_called()
+
+    async def test_local_behavior_when_remote_url_absent(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig()
+
+        local_result = MagicMock()
+        with patch(
+            "content_core.processors.document.docling._extract_docling_remote",
+        ) as mock_remote, patch(
+            "content_core.processors.document.docling._extract_docling_local",
+            return_value=local_result,
+        ) as mock_local:
+            result = await extract_docling(str(source), config)
+
+        assert result is local_result
+        mock_local.assert_awaited_once_with(str(source), config)
+        mock_remote.assert_not_called()
+
+
+class TestDoclingServeHelpers:
+    def test_normalize_docling_api_url(self):
+        assert (
+            _normalize_docling_api_url("https://docling.example")
+            == "https://docling.example/v1"
+        )
+        assert (
+            _normalize_docling_api_url("https://docling.example/")
+            == "https://docling.example/v1"
+        )
+        assert (
+            _normalize_docling_api_url("https://docling.example/v1")
+            == "https://docling.example/v1"
+        )
+        assert (
+            _normalize_docling_api_url("https://docling.example/v1/")
+            == "https://docling.example/v1"
+        )
+        assert (
+            _normalize_docling_api_url("https://docling.example/v1/convert/file")
+            == "https://docling.example/v1"
+        )
+
+    def test_docling_file_endpoint(self):
+        assert (
+            _docling_file_endpoint("https://docling.example")
+            == "https://docling.example/v1/convert/file"
+        )
+        assert (
+            _docling_file_endpoint("https://docling.example/v1")
+            == "https://docling.example/v1/convert/file"
+        )
+
+    def test_authentication_header(self):
+        config = ContentCoreConfig(docling_api_key="secret-token")
+        headers = _docling_headers(config)
+        assert headers["accept"] == "application/json"
+        assert headers["X-Api-Key"] == "secret-token"
+
+    def test_ocr_option_mapping(self):
+        config = ContentCoreConfig(
+            docling_ocr=False,
+            docling_formulas=True,
+            docling_vision=True,
+        )
+        assert _docling_form_fields(config) == [
+            ("to_formats", "md"),
+            ("do_ocr", "false"),
+            ("abort_on_error", "true"),
+            ("do_formula_enrichment", "true"),
+            ("do_picture_description", "true"),
+            ("do_chart_extraction", "true"),
+        ]
+
+
+class TestRemoteDoclingServe:
+    async def test_remote_success(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(
+            docling_api_url="https://docling.example", docling_timeout=42
+        )
+        payload = {"document": {"md_content": "# Converted"}}
+        session = FakeSession(response=FakeResponse(body=json.dumps(payload)))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await extract_docling(str(source), config)
+
+        assert result.content == "# Converted"
+        assert result.metadata["docling_backend"] == "remote"
+        args, kwargs = session.post_calls[0]
+        assert args[0] == "https://docling.example/v1/convert/file"
+        assert kwargs["headers"]["accept"] == "application/json"
+        assert kwargs["timeout"].total == 42
+
+    async def test_remote_success_with_authentication_header(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(
+            docling_api_url="https://docling.example",
+            docling_api_key="secret-token",
+        )
+        payload = {"document": {"md_content": "# Converted"}}
+        session = FakeSession(response=FakeResponse(body=json.dumps(payload)))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            await extract_docling(str(source), config)
+
+        _, kwargs = session.post_calls[0]
+        assert kwargs["headers"]["X-Api-Key"] == "secret-token"
+
+    async def test_remote_timeout(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(
+            docling_api_url="https://docling.example", docling_timeout=7
+        )
+        session = FakeSession(exc=asyncio.TimeoutError())
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="timed out"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_connection_failure(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+        session = FakeSession(exc=aiohttp.ClientConnectionError("dns failure"))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="request failed"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_server_error(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+        session = FakeSession(
+            response=FakeResponse(
+                status=502, body=json.dumps({"detail": "bad gateway"})
+            )
+        )
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="HTTP 502: bad gateway"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_malformed_response(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+        session = FakeSession(response=FakeResponse(body="not json"))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="invalid JSON"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_empty_content(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+        session = FakeSession(
+            response=FakeResponse(body=json.dumps({"document": {"md_content": "   "}}))
+        )
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="no markdown content"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_conversion_failure_reported(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(docling_api_url="https://docling.example")
+        payload = {"document": {"failure": "conversion failed"}}
+        session = FakeSession(response=FakeResponse(body=json.dumps(payload)))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            with pytest.raises(DocumentExtractionError, match="conversion failed"):
+                await extract_docling(str(source), config)
+
+    async def test_remote_non_markdown_output_rejected(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(
+            docling_api_url="https://docling.example",
+            docling_output_format="html",
+        )
+
+        with pytest.raises(
+            DocumentExtractionError,
+            match="supports only docling_output_format='markdown'",
+        ):
+            await extract_docling(str(source), config)

--- a/tests/unit/test_docling_extraction.py
+++ b/tests/unit/test_docling_extraction.py
@@ -335,6 +335,18 @@ class TestDoclingServeHelpers:
             ("do_chart_extraction", "true"),
         ]
 
+    def test_optional_form_fields_omitted_when_disabled(self):
+        config = ContentCoreConfig(
+            docling_ocr=True,
+            docling_formulas=False,
+            docling_vision=False,
+        )
+        assert _docling_form_fields(config) == [
+            ("to_formats", "md"),
+            ("do_ocr", "true"),
+            ("abort_on_error", "true"),
+        ]
+
 
 class TestRemoteDoclingServe:
     async def test_remote_success(self, tmp_path):
@@ -392,6 +404,27 @@ class TestRemoteDoclingServe:
         ):
             with pytest.raises(DocumentExtractionError, match="timed out"):
                 await extract_docling(str(source), config)
+
+    async def test_remote_sends_do_ocr_false_when_disabled(self, tmp_path):
+        source = tmp_path / "report.pdf"
+        source.write_bytes(b"pdf")
+        config = ContentCoreConfig(
+            docling_api_url="https://docling.example",
+            docling_ocr=False,
+        )
+        payload = {"document": {"md_content": "# Converted"}}
+        session = FakeSession(response=FakeResponse(body=json.dumps(payload)))
+
+        with patch(
+            "content_core.processors.document.docling.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            await extract_docling(str(source), config)
+
+        _, kwargs = session.post_calls[0]
+        fields = kwargs["data"]._fields
+        form_values = {field[0].get("name"): field[2] for field in fields}
+        assert form_values["do_ocr"] == "false"
 
     async def test_remote_connection_failure(self, tmp_path):
         source = tmp_path / "report.pdf"
@@ -465,9 +498,7 @@ class TestRemoteDoclingServe:
             with pytest.raises(DocumentExtractionError, match="conversion failed"):
                 await extract_docling(str(source), config)
 
-    async def test_remote_non_markdown_output_rejected(self, tmp_path):
-        source = tmp_path / "report.pdf"
-        source.write_bytes(b"pdf")
+    async def test_remote_non_markdown_output_rejected(self):
         config = ContentCoreConfig(
             docling_api_url="https://docling.example",
             docling_output_format="html",
@@ -477,4 +508,4 @@ class TestRemoteDoclingServe:
             DocumentExtractionError,
             match="supports only docling_output_format='markdown'",
         ):
-            await extract_docling(str(source), config)
+            await extract_docling("/fake/report.pdf", config)

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -151,6 +151,32 @@ async def test_url_pdf_downloads_and_calls_extract_pdf():
         assert result.source_type == "url"
 
 
+@pytest.mark.asyncio
+async def test_url_docling_supported_downloads_when_remote_api_configured():
+    expected = _make_output(source_type="file", identified_type="text/csv")
+    cfg = ContentCoreConfig(docling_api_url="https://docling.example")
+    with patch(
+        "content_core.extraction.detect_remote_mime",
+        new_callable=AsyncMock,
+        return_value="text/csv",
+    ), patch(
+        "content_core.extraction._download_remote_file",
+        new_callable=AsyncMock,
+        return_value="/tmp/fake.csv",
+    ) as mock_download, patch(
+        "content_core.extraction._extract_file",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_extract_file, patch(
+        "content_core.extraction.DOCLING_AVAILABLE",
+        False,
+    ):
+        result = await extract_content(url="https://example.com/doc.csv", config=cfg)
+        mock_download.assert_awaited_once()
+        mock_extract_file.assert_awaited_once()
+        assert result.source_type == "url"
+
+
 # ---------------------------------------------------------------------------
 # 5. File with PDF MIME -> extract_pdf_file
 # ---------------------------------------------------------------------------
@@ -195,6 +221,31 @@ async def test_file_pdf_uses_docling_when_remote_api_configured():
 
 
 @pytest.mark.asyncio
+async def test_file_pdf_uses_simple_pdf_when_remote_api_configured_but_engine_is_simple():
+    expected = _make_output(identified_type="application/pdf")
+    cfg = ContentCoreConfig(
+        docling_api_url="https://docling.example",
+        document_engine="simple",
+    )
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+    ) as mock_docling, patch(
+        "content_core.extraction.extract_pdf_file",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_pdf:
+        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
+        mock_pdf.assert_awaited_once()
+        mock_docling.assert_not_awaited()
+        assert result is expected
+
+
+@pytest.mark.asyncio
 async def test_file_pdf_uses_simple_pdf_when_remote_url_absent_and_docling_unavailable():
     expected = _make_output(identified_type="application/pdf")
     cfg = ContentCoreConfig(document_engine="auto")
@@ -216,6 +267,32 @@ async def test_file_pdf_uses_simple_pdf_when_remote_url_absent_and_docling_unava
         result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
         mock_pdf.assert_awaited_once()
         mock_docling.assert_not_awaited()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_file_pdf_falls_back_when_docling_import_fails_in_auto_mode():
+    expected = _make_output(identified_type="application/pdf")
+    cfg = ContentCoreConfig(document_engine="auto")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.DOCLING_AVAILABLE",
+        True,
+    ), patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+        side_effect=ImportError("docling import failed"),
+    ) as mock_docling, patch(
+        "content_core.extraction.extract_pdf_file",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_pdf:
+        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
+        mock_docling.assert_awaited_once()
+        mock_pdf.assert_awaited_once()
         assert result is expected
 
 
@@ -298,6 +375,53 @@ async def test_file_audio_calls_transcribe_audio():
     ) as mock:
         result = await extract_content(file_path="/tmp/test.mp3")
         mock.assert_awaited_once()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_file_audio_with_remote_docling_still_uses_audio_processor():
+    expected = _make_output(identified_type="audio/mp3")
+    cfg = ContentCoreConfig(docling_api_url="https://docling.example")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="audio/mp3",
+    ), patch(
+        "content_core.extraction.transcribe_audio",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_audio, patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+    ) as mock_docling:
+        result = await extract_content(file_path="/tmp/test.mp3", config=cfg)
+        mock_audio.assert_awaited_once()
+        mock_docling.assert_not_awaited()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_url_docling_supported_does_not_download_when_engine_is_simple():
+    expected = _make_output(source_type="url", identified_type="html")
+    cfg = ContentCoreConfig(
+        docling_api_url="https://docling.example",
+        document_engine="simple",
+    )
+    with patch(
+        "content_core.extraction.detect_remote_mime",
+        new_callable=AsyncMock,
+        return_value="text/csv",
+    ), patch(
+        "content_core.extraction._download_remote_file",
+        new_callable=AsyncMock,
+    ) as mock_download, patch(
+        "content_core.extraction.extract_from_url",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_extract_url:
+        result = await extract_content(url="https://example.com/doc.csv", config=cfg)
+        mock_download.assert_not_awaited()
+        mock_extract_url.assert_awaited_once()
         assert result is expected
 
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -296,36 +296,7 @@ async def test_file_pdf_falls_back_when_docling_import_fails_in_auto_mode():
         assert result is expected
 
 
-@pytest.mark.asyncio
-async def test_file_pdf_auto_falls_back_when_find_spec_succeeds_but_imports_fail():
-    """Simulate find_spec succeeding but _load_docling_classes raising ImportError
-    at runtime, verifying auto mode falls back to simple processor."""
-    expected = _make_output(identified_type="application/pdf")
-    cfg = ContentCoreConfig(document_engine="auto")
-    with patch(
-        "content_core.content.identification.get_file_type",
-        new_callable=AsyncMock,
-        return_value="application/pdf",
-    ), patch(
-        "content_core.extraction.is_docling_capable",
-        return_value=True,
-    ), patch(
-        "content_core.extraction.extract_docling",
-        new_callable=AsyncMock,
-        side_effect=ImportError("broken docling"),
-    ) as mock_docling, patch(
-        "content_core.extraction.extract_pdf_file",
-        new_callable=AsyncMock,
-        return_value=expected,
-    ) as mock_pdf:
-        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
-        mock_docling.assert_awaited_once()
-        mock_pdf.assert_awaited_once()
-        assert result is expected
-
-
-@pytest.mark.asyncio
-async def test_standard_routing_agrees_with_docling_fallback():
+def test_standard_routing_agrees_with_docling_fallback():
     """Routing via _route_for_mime(fallback) and _route_standard_for_mime must
     produce the same route for every standard MIME type when Docling is unavailable."""
     cfg = ContentCoreConfig(document_engine="simple")

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -168,8 +168,8 @@ async def test_url_docling_supported_downloads_when_remote_api_configured():
         new_callable=AsyncMock,
         return_value=expected,
     ) as mock_extract_file, patch(
-        "content_core.extraction.DOCLING_AVAILABLE",
-        False,
+        "content_core.extraction.is_docling_capable",
+        return_value=False,
     ):
         result = await extract_content(url="https://example.com/doc.csv", config=cfg)
         mock_download.assert_awaited_once()
@@ -254,8 +254,8 @@ async def test_file_pdf_uses_simple_pdf_when_remote_url_absent_and_docling_unava
         new_callable=AsyncMock,
         return_value="application/pdf",
     ), patch(
-        "content_core.extraction.DOCLING_AVAILABLE",
-        False,
+        "content_core.extraction.is_docling_capable",
+        return_value=False,
     ), patch(
         "content_core.extraction.extract_docling",
         new_callable=AsyncMock,
@@ -279,8 +279,8 @@ async def test_file_pdf_falls_back_when_docling_import_fails_in_auto_mode():
         new_callable=AsyncMock,
         return_value="application/pdf",
     ), patch(
-        "content_core.extraction.DOCLING_AVAILABLE",
-        True,
+        "content_core.extraction.is_docling_capable",
+        return_value=True,
     ), patch(
         "content_core.extraction.extract_docling",
         new_callable=AsyncMock,
@@ -294,6 +294,63 @@ async def test_file_pdf_falls_back_when_docling_import_fails_in_auto_mode():
         mock_docling.assert_awaited_once()
         mock_pdf.assert_awaited_once()
         assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_file_pdf_auto_falls_back_when_find_spec_succeeds_but_imports_fail():
+    """Simulate find_spec succeeding but _load_docling_classes raising ImportError
+    at runtime, verifying auto mode falls back to simple processor."""
+    expected = _make_output(identified_type="application/pdf")
+    cfg = ContentCoreConfig(document_engine="auto")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.is_docling_capable",
+        return_value=True,
+    ), patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+        side_effect=ImportError("broken docling"),
+    ) as mock_docling, patch(
+        "content_core.extraction.extract_pdf_file",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_pdf:
+        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
+        mock_docling.assert_awaited_once()
+        mock_pdf.assert_awaited_once()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_standard_routing_agrees_with_docling_fallback():
+    """Routing via _route_for_mime(fallback) and _route_standard_for_mime must
+    produce the same route for every standard MIME type when Docling is unavailable."""
+    cfg = ContentCoreConfig(document_engine="simple")
+    from content_core.extraction import _route_for_mime, _route_standard_for_mime
+
+    standard_mimes = [
+        "application/pdf",
+        "application/epub+zip",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "video/mp4",
+        "audio/mp3",
+        "text/plain",
+    ]
+    for mime in standard_mimes:
+        route = _route_for_mime(mime, cfg)
+        standard = _route_standard_for_mime(mime)
+        assert (
+            route == standard
+        ), f"MIME {mime}: _route_for_mime returned {route}, _route_standard_for_mime returned {standard}"
+
+    # Unsupported types
+    assert _route_for_mime("application/x-unknown", cfg) is None
+    assert _route_standard_for_mime("application/x-unknown") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -25,7 +25,9 @@ def _make_output(**kwargs) -> ExtractionOutput:
 async def test_text_input_calls_process_text():
     expected = _make_output(source_type="text")
     with patch(
-        "content_core.extraction.process_text", new_callable=AsyncMock, return_value=expected
+        "content_core.extraction.process_text",
+        new_callable=AsyncMock,
+        return_value=expected,
     ) as mock:
         result = await extract_content(content="hello")
         mock.assert_awaited_once()
@@ -39,7 +41,9 @@ async def test_text_input_calls_process_text():
 async def test_youtube_url_calls_extract_youtube():
     expected = _make_output(source_type="url", identified_type="youtube")
     with patch(
-        "content_core.extraction.extract_youtube", new_callable=AsyncMock, return_value=expected
+        "content_core.extraction.extract_youtube",
+        new_callable=AsyncMock,
+        return_value=expected,
     ) as mock:
         result = await extract_content(url="https://www.youtube.com/watch?v=abc")
         mock.assert_awaited_once()
@@ -50,7 +54,9 @@ async def test_youtube_url_calls_extract_youtube():
 async def test_youtu_be_url_calls_extract_youtube():
     expected = _make_output(source_type="url", identified_type="youtube")
     with patch(
-        "content_core.extraction.extract_youtube", new_callable=AsyncMock, return_value=expected
+        "content_core.extraction.extract_youtube",
+        new_callable=AsyncMock,
+        return_value=expected,
     ) as mock:
         result = await extract_content(url="https://youtu.be/abc")
         mock.assert_awaited_once()
@@ -64,7 +70,9 @@ async def test_youtu_be_url_calls_extract_youtube():
 async def test_reddit_url_calls_extract_reddit():
     expected = _make_output(source_type="url", identified_type="reddit")
     with patch(
-        "content_core.extraction.extract_reddit", new_callable=AsyncMock, return_value=expected
+        "content_core.extraction.extract_reddit",
+        new_callable=AsyncMock,
+        return_value=expected,
     ) as mock:
         result = await extract_content(
             url="https://www.reddit.com/r/python/comments/abc123/some_post/"
@@ -161,6 +169,53 @@ async def test_file_pdf_calls_extract_pdf_file():
     ) as mock:
         result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
         mock.assert_awaited_once()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_file_pdf_uses_docling_when_remote_api_configured():
+    expected = _make_output(identified_type="application/pdf")
+    cfg = ContentCoreConfig(docling_api_url="https://docling.example")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_docling, patch(
+        "content_core.extraction.extract_pdf_file",
+        new_callable=AsyncMock,
+    ) as mock_pdf:
+        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
+        mock_docling.assert_awaited_once()
+        mock_pdf.assert_not_awaited()
+        assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_file_pdf_uses_simple_pdf_when_remote_url_absent_and_docling_unavailable():
+    expected = _make_output(identified_type="application/pdf")
+    cfg = ContentCoreConfig(document_engine="auto")
+    with patch(
+        "content_core.content.identification.get_file_type",
+        new_callable=AsyncMock,
+        return_value="application/pdf",
+    ), patch(
+        "content_core.extraction.DOCLING_AVAILABLE",
+        False,
+    ), patch(
+        "content_core.extraction.extract_docling",
+        new_callable=AsyncMock,
+    ) as mock_docling, patch(
+        "content_core.extraction.extract_pdf_file",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_pdf:
+        result = await extract_content(file_path="/tmp/test.pdf", config=cfg)
+        mock_pdf.assert_awaited_once()
+        mock_docling.assert_not_awaited()
         assert result is expected
 
 
@@ -297,7 +352,9 @@ async def test_config_passed_to_processor():
     custom_cfg = ContentCoreConfig(url_engine="firecrawl")
     expected = _make_output(source_type="text")
     with patch(
-        "content_core.extraction.process_text", new_callable=AsyncMock, return_value=expected
+        "content_core.extraction.process_text",
+        new_callable=AsyncMock,
+        return_value=expected,
     ) as mock:
         await extract_content(content="hello", config=custom_cfg)
         # Verify the custom config was passed
@@ -314,9 +371,11 @@ async def test_docling_flags_warning_without_engine():
     """Warning should be logged when docling flags set but engine is not docling."""
     cfg = ContentCoreConfig(docling_formulas=True, document_engine="simple")
 
-    with patch("content_core.extraction.extract_pdf_file", new_callable=AsyncMock) as mock_pdf, \
-         patch("content_core.content.identification.get_file_type", new_callable=AsyncMock) as mock_type, \
-         patch("content_core.extraction.logger") as mock_logger:
+    with patch(
+        "content_core.extraction.extract_pdf_file", new_callable=AsyncMock
+    ) as mock_pdf, patch(
+        "content_core.content.identification.get_file_type", new_callable=AsyncMock
+    ) as mock_type, patch("content_core.extraction.logger") as mock_logger:
         mock_type.return_value = "application/pdf"
         mock_pdf.return_value = ExtractionOutput(content="text")
 


### PR DESCRIPTION
## Summary

This PR adds optional support for using an external Docling Serve instance.

Currently, Content Core supports local Docling execution only.
Many deployments already operate a shared Docling Serve instance for
multiple applications. This change allows Content Core to reuse that
existing infrastructure.

## Features

- optional remote Docling Serve backend
- `DOCLING_API_URL`
- `DOCLING_API_KEY`
- configurable timeout
- remote-first routing
- no silent fallback if a configured remote service fails
- existing behavior is preserved when no remote Docling URL is configured.

### Configuration

The implementation accepts both

- `CCORE_DOCLING_API_URL`
- `DOCLING_API_URL`

to match existing Content Core naming conventions while also making
integration into higher-level applications straightforward.

### HTTP implementation

The remote client follows the project's existing asynchronous HTTP
pattern and intentionally does not introduce a Docling-specific runtime
dependency.

## Backward compatibility

Existing installations remain unchanged unless
`DOCLING_API_URL` is configured.

## Validation

Feature-specific validation:

- ✅ Remote Docling extraction
- ✅ Routing and fallback behavior
- ✅ Configuration and secret redaction
- ✅ CLI behavior
- ✅ Ruff lint
- ✅ Changed-file formatting

Full functional test suite:

- 327 passed
- 12 deselected

Two Windows timing-sensitive performance tests may fail intermittently. The
same failures were reproduced against an unmodified upstream/main checkout and
are unrelated to this change.

## Follow-up

A separate Open Notebook PR will expose the new configuration
through the application and Docker configuration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

