### PR TITLE
chore: ignore the whole .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ node_modules/
 
 claude-logs
 specs/
-.claude/sessions
+.claude/


### PR DESCRIPTION
Widens the existing `.claude/sessions` ignore rule to cover `.claude/` entirely.

Everything under that directory is developer-specific local agent tooling —
`settings.local.json`, session state, and locally-authored skills. None of it
affects the published package or other contributors' workflows, so tracking
parts of it while ignoring others just invites accidental commits of local
settings.

One-line change, no code impact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

