### PR TITLE
ci: add packaging gate and run integration tests in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,119 @@
+name: Package
+
+# Reusable packaging gate: builds the wheel and exercises all three consumer
+# surfaces (library, CLI, MCP server) from the built artifact, with the repo
+# off the path. Called by test.yml (PRs / main) and by publish.yml (tags), so
+# a tag can never publish an artifact that failed this gate.
+on:
+  workflow_call:
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Build wheel and sdist
+      run: |
+        rm -rf dist
+        uv build
+        ls -la dist/
+
+    - name: Assert runtime assets are inside the wheel
+      run: |
+        python - <<'PY'
+        import glob, pathlib, sys, zipfile
+
+        src = pathlib.Path("src/content_core")
+        expected = sorted(
+            f"content_core/{p.relative_to(src).as_posix()}"
+            for p in src.rglob("*")
+            if p.is_file()
+            and p.suffix != ".py"
+            and "__pycache__" not in p.parts
+            and p.name != ".DS_Store"
+        )
+        if not expected:
+            sys.exit("no non-.py runtime assets found on disk - check the glob")
+
+        wheels = glob.glob("dist/content_core-*.whl")
+        if len(wheels) != 1:
+            sys.exit(f"expected exactly one wheel, got {wheels}")
+        with zipfile.ZipFile(wheels[0]) as zf:
+            names = set(zf.namelist())
+
+        missing = [name for name in expected if name not in names]
+        if missing:
+            sys.exit(f"runtime assets missing from wheel: {missing}")
+        print("runtime assets present in wheel:", expected)
+        PY
+
+    - name: Bare-install import from the wheel (no extras)
+      run: |
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          python -c "import content_core; print(content_core.__name__, 'import OK')"
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          python -c "from content_core import extract_content, summarize, ContentCoreConfig; print('public API OK')"
+
+    - name: CLI smoke from the wheel
+      run: |
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          content-core --help
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          content-core extract tests/input_content/file.txt
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          content-core extract tests/input_content/file.pdf --format json
+
+    - name: MCP stdio handshake from the wheel
+      run: |
+        cat > "$RUNNER_TEMP/mcp_smoke.py" <<'PY'
+        import json, subprocess
+
+        req = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "clientInfo": {"name": "ci-package-gate", "version": "1"}}}
+        p = subprocess.run(["content-core-mcp"], input=json.dumps(req) + "\n",
+                           capture_output=True, text=True, timeout=120)
+        line = next((l for l in p.stdout.splitlines() if '"result"' in l), None)
+        assert line, f"no MCP response.\nstdout={p.stdout[:500]}\nstderr={p.stderr[-800:]}"
+        print("MCP handshake OK:", json.loads(line)["result"]["serverInfo"])
+        PY
+        uv run --isolated --no-project --with dist/content_core-*.whl \
+          python "$RUNNER_TEMP/mcp_smoke.py"
+
+    - name: Wheel version matches pyproject version
+      run: |
+        python - <<'PY'
+        import glob, pathlib, re, sys
+
+        # tomllib is 3.11+, this job runs on 3.10 - read the [project] version directly.
+        text = pathlib.Path("pyproject.toml").read_text()
+        project = re.split(r"(?m)^\[", text)
+        section = next((s for s in project if s.startswith("project]")), None)
+        if section is None:
+            sys.exit("no [project] section in pyproject.toml")
+        found = re.search(r'(?m)^version\s*=\s*"([^"]+)"', section)
+        if not found:
+            sys.exit("no version key in [project] section of pyproject.toml")
+        expected = found.group(1)
+
+        wheels = glob.glob("dist/content_core-*.whl")
+        if len(wheels) != 1:
+            sys.exit(f"expected exactly one wheel, got {wheels}")
+        name = pathlib.Path(wheels[0]).name
+        match = re.match(r"content_core-([^-]+)-", name)
+        if not match:
+            sys.exit(f"could not parse version from wheel name {name!r}")
+        if match.group(1) != expected:
+            sys.exit(f"wheel version {match.group(1)!r} != pyproject version {expected!r}")
+        print(f"version match OK: {expected}")
+        PY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,11 @@ on:
       - '[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
+  package:
+    uses: ./.github/workflows/package.yml
+
   publish:
+    needs: package
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,8 @@ jobs:
     - name: Install dependencies
       run: uv sync --group dev
 
-    - name: Run unit tests
-      run: uv run pytest tests/unit -v --tb=short
+    - name: Run unit and integration tests
+      run: uv run pytest tests/unit tests/integration -v --tb=short
+
+  package:
+    uses: ./.github/workflows/package.yml


### PR DESCRIPTION
Closes #48

## Problem

`publish.yml` checked out, built and uploaded to PyPI on a tag push with no tests
at all. PyPI is immutable, so a bad publish burns the version permanently — and
this is not hypothetical: v2.0.1 was a hotfix for a Jinja template that never made
it into the built wheel (8614c96), while the full suite was green because the file
was on disk.

Separately, `test.yml` ran only `tests/unit`, even though `tests/integration`
needs no network and no credentials.

## Change

New reusable workflow `.github/workflows/package.yml` (`on: workflow_call`),
with a `package` job that builds the artifact and exercises all three consumer
surfaces *from the wheel*, with the repo off the path:

1. `rm -rf dist && uv build`
2. assert every non-`.py` runtime asset on disk is present inside the wheel
   (today that is `py.typed`) — this is the check that would have caught v2.0.1
3. bare-install import with no extras, including
   `from content_core import extract_content, summarize, ContentCoreConfig`
   — catches an accidental hard top-level import of an optional SDK
   (`docling`, `crawl4ai`, `langchain`)
4. `content-core --help` plus real `content-core extract` runs against fixtures
5. a JSON-RPC `initialize` handshake against `content-core-mcp` (the way Claude
   Desktop consumes the package), verifying the server *answers*
6. wheel version equals the `pyproject.toml` version

It is reusable rather than a plain job because `test.yml` fires on push/PR to
`main` while `publish.yml` fires on tags — a callable workflow serves both
without duplicating steps.

- `test.yml`: runs `tests/unit tests/integration`, and calls the packaging
  workflow via `uses: ./.github/workflows/package.yml`.
- `publish.yml`: the `publish` job now `needs:` the called packaging job, so a
  tag cannot publish an artifact that failed the gate.

Commands are the ones already verified in the release runbook's "Packaging gate"
section.

## Deliberately excluded

- **Extras resolution** (runbook step 5): `docling` pulls transformers/peft and
  takes minutes — unacceptable for a PR gate.
- **`timeout 5 content-core-mcp`** for the MCP check: `timeout` is absent on
  stock macOS, and "didn't crash in 5s" would not prove the server responds.
  The `subprocess` handshake script is used instead.

## Known trade-off

`publish` still runs its own `uv build` rather than consuming the exact artifact
the `package` job validated. Passing the wheel between jobs via
`upload-artifact`/`download-artifact` would make the release atomic; left out
here to keep the change minimal, and worth a follow-up.

## Testing

- `uv run pytest tests/unit tests/integration -v` — 292 passed in ~50s, no
  network or credentials needed.
- All six gate steps run locally against a fresh `uv build` of this branch:
  asset check (`content_core/py.typed` present), bare import, public API import,
  `--help`, `extract file.txt`, `extract file.pdf --format json`, MCP handshake
  (`serverInfo` returned), version match `2.0.4`.
- All three workflow files parse as YAML (`actionlint` not available locally).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

