### PR TITLE
fix(logging): stop reconfiguring loguru globally at import time

### DIFF
--- a/src/content_core/__init__.py
+++ b/src/content_core/__init__.py
@@ -1,5 +1,6 @@
 """Content Core — Extract and summarize content from any source."""
 from dotenv import load_dotenv
+from loguru import logger
 
 load_dotenv()
 
@@ -12,10 +13,13 @@ from content_core.common.state import ExtractionInput, ExtractionOutput, FileSup
 # Convenience alias
 extract = extract_content
 
-# Configure default logging
-configure_logging(debug=False)
+# Libraries must not configure logging — loguru's logger is a process-wide
+# singleton. Stay silent by default; applications opt in via
+# `logger.enable("content_core")` or `content_core.configure_logging()`.
+logger.disable("content_core")
 
 __all__ = [
+    "configure_logging",
     "extract_content",
     "extract",
     "check_file_support",

--- a/src/content_core/cli.py
+++ b/src/content_core/cli.py
@@ -15,11 +15,16 @@ def _get_version():
 @click.group()
 @click.version_option(package_name="content-core")
 @click.option("--debug", is_flag=True, help="Enable debug logging")
-def cli(debug):
+@click.pass_context
+def cli(ctx, debug):
     """Content Core — Extract and summarize content from any source."""
     # The CLI is an application, so it may configure logging. The library keeps
     # itself disabled by default; this re-enables it for CLI runs.
     configure_logging(debug=debug)
+    # Stashed so subcommands that hand off to another entrypoint (`mcp`) can
+    # forward the flag instead of letting it be reconfigured away.
+    ctx.ensure_object(dict)
+    ctx.obj["debug"] = debug
 
 
 @cli.command()
@@ -88,11 +93,12 @@ def summarize(content, context):
 
 
 @cli.command()
-def mcp():
+@click.pass_context
+def mcp(ctx):
     """Start the MCP server."""
     from content_core.mcp.server import main
 
-    main()
+    main(debug=ctx.obj.get("debug", False))
 
 
 @cli.group()

--- a/src/content_core/cli.py
+++ b/src/content_core/cli.py
@@ -17,8 +17,9 @@ def _get_version():
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def cli(debug):
     """Content Core — Extract and summarize content from any source."""
-    if debug:
-        configure_logging(debug=True)
+    # The CLI is an application, so it may configure logging. The library keeps
+    # itself disabled by default; this re-enables it for CLI runs.
+    configure_logging(debug=debug)
 
 
 @cli.command()

--- a/src/content_core/logging.py
+++ b/src/content_core/logging.py
@@ -1,15 +1,54 @@
+import os
 import sys
+
 from loguru import logger
+
+# Id of the stderr sink this module added, so repeat calls replace it.
+_sink_id = None
+
 
 def configure_logging(debug=False):
     """
-    Configure the global logger for the application.
-    
-    Args:
-        debug (bool): If True, set logging level to DEBUG; otherwise, set to INFO.
-    """
-    logger.remove()  # Remove any existing handlers
-    logger.add(sys.stderr, level="DEBUG" if debug else "INFO")
+    Enable and configure `content_core` logging.
 
-# Initial configuration with default level (INFO)
-configure_logging(debug=False)
+    This is an *application-level* opt-in. As a library, ``content_core``
+    disables its own logging at import time (``logger.disable("content_core")``)
+    and never touches the host application's handlers. Call this only from an
+    application entrypoint (CLI, MCP server, your own ``main()``).
+
+    The sink it installs is deliberately unfiltered — an application entrypoint
+    wants third-party loguru records too. A host application that already owns
+    its own handlers should therefore NOT call this (it would get a second,
+    duplicating stderr sink); it should just call ``logger.enable("content_core")``.
+
+    Note: this adds a stderr sink to loguru's global logger; it deliberately does
+    NOT call the blanket ``logger.remove()``, so any handlers the host app
+    registered survive. It only drops loguru's own auto-added default sink (id 0,
+    absent as soon as the host has called ``logger.remove()``) and any sink a
+    previous ``configure_logging`` call added, so repeat calls do not duplicate
+    output.
+
+    Args:
+        debug (bool): If True, force level DEBUG. Otherwise use the
+            ``LOGURU_LEVEL`` environment variable, defaulting to INFO.
+    """
+    global _sink_id
+
+    logger.enable("content_core")
+
+    if _sink_id is not None:
+        try:
+            logger.remove(_sink_id)
+        except ValueError:
+            pass
+        _sink_id = None
+
+    # Drop loguru's default stderr sink so our sink does not double every line.
+    # Raises ValueError when the host app has already removed it — nothing to do.
+    try:
+        logger.remove(0)
+    except ValueError:
+        pass
+
+    level = "DEBUG" if debug else os.environ.get("LOGURU_LEVEL", "INFO")
+    _sink_id = logger.add(sys.stderr, level=level)

--- a/src/content_core/mcp/server.py
+++ b/src/content_core/mcp/server.py
@@ -93,11 +93,17 @@ async def summarize_content(
         return f"Error: {e}"
 
 
-def main():
-    """Entry point for the MCP server."""
+def main(debug: bool = False):
+    """Entry point for the MCP server.
+
+    Args:
+        debug: Force DEBUG level. Forwarded by ``content-core --debug mcp``; the
+            bare ``content-core-mcp`` console script has no click context and
+            takes the default, configuring itself since nothing else will.
+    """
     # Configure logging here, not at import time: stderr only, so nothing ever
     # contaminates the stdout JSON-RPC stream.
-    configure_logging()
+    configure_logging(debug=debug)
     logger.info("Starting Content Core MCP Server")
     mcp.run()
 

--- a/src/content_core/mcp/server.py
+++ b/src/content_core/mcp/server.py
@@ -1,12 +1,8 @@
 """Content Core MCP Server — extract and summarize content."""
-import sys
-
 from fastmcp import FastMCP
 from loguru import logger
 
-# Configure loguru for MCP (stderr only, no stdout interference)
-logger.remove()
-logger.add(sys.stderr, level="INFO")
+from content_core.logging import configure_logging
 
 mcp = FastMCP("Content Core")
 
@@ -99,6 +95,9 @@ async def summarize_content(
 
 def main():
     """Entry point for the MCP server."""
+    # Configure logging here, not at import time: stderr only, so nothing ever
+    # contaminates the stdout JSON-RPC stream.
+    configure_logging()
     logger.info("Starting Content Core MCP Server")
     mcp.run()
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -95,6 +95,59 @@ def test_configure_logging_does_not_duplicate_output():
     assert proc.stderr.count(LIBRARY_LOG) == 2, proc.stderr
 
 
+def test_cli_debug_flag_reaches_mcp_entrypoint():
+    """`content-core --debug mcp` must end up at DEBUG, not be reset to INFO.
+
+    Regression: moving the logging setup into `main()` made it reconfigure at
+    the default level, silently discarding the CLI's --debug flag.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "from unittest.mock import patch\n"
+            "from click.testing import CliRunner\n"
+            "from content_core.cli import cli\n"
+            "with patch('content_core.mcp.server.mcp.run'), \\\n"
+            "     patch('content_core.logging.configure_logging') as cfg:\n"
+            "    import content_core.mcp.server as srv\n"
+            "    with patch.object(srv, 'configure_logging', cfg):\n"
+            "        res = CliRunner().invoke(cli, ['--debug', 'mcp'])\n"
+            "    assert res.exit_code == 0, res.output\n"
+            "print([c.kwargs.get('debug') for c in cfg.call_args_list])\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    # The MCP entrypoint must have been configured with debug=True.
+    assert "True" in proc.stdout, proc.stdout
+
+
+def test_mcp_entrypoint_configures_itself_without_click_context():
+    """The bare `content-core-mcp` console script still configures logging."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from unittest.mock import patch\n"
+            "import content_core.mcp.server as srv\n"
+            "with patch.object(srv, 'mcp'), \\\n"
+            "     patch.object(srv, 'configure_logging') as cfg:\n"
+            "    srv.main()\n"
+            "assert cfg.call_count == 1, cfg.call_args_list\n"
+            "print('debug=', cfg.call_args.kwargs.get('debug'))\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "debug= False" in proc.stdout, proc.stdout
+
+
 def test_mcp_server_import_does_not_configure_logging():
     """Importing the MCP server module must not reconfigure logging either."""
     proc = run_host_app(extra="import content_core.mcp.server  # noqa: F401\n")

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,103 @@
+"""Logging isolation tests (issue #47).
+
+loguru's `logger` is a process-wide singleton, so these tests run each scenario
+in a **subprocess** — configuring logging in-process would leak handler state
+into every other test in the session.
+"""
+import subprocess
+import sys
+
+import pytest
+
+# A "host application" that owns its logging config, then imports content_core.
+HOST_APP = """
+import sys
+from loguru import logger
+
+# The host app owns the single remove()/add() pair.
+logger.remove()
+logger.add(sys.stderr, level="DEBUG", format="{level} | {message}")
+
+import content_core  # must not touch the config above
+
+__EXTRA__
+
+logger.debug("HOST_DEBUG_SURVIVES")
+"""
+
+
+def run_host_app(extra=""):
+    """Run the host-app snippet in a fresh interpreter, return CompletedProcess."""
+    # str.replace, not str.format — the snippet contains loguru format braces.
+    return subprocess.run(
+        [sys.executable, "-c", HOST_APP.replace("__EXTRA__", extra)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.fixture(scope="module")
+def default_import():
+    return run_host_app()
+
+
+def test_host_handler_survives_import(default_import):
+    """Importing content_core must not clobber the host's DEBUG handler."""
+    assert default_import.returncode == 0, default_import.stderr
+    assert "HOST_DEBUG_SURVIVES" in default_import.stderr
+
+
+def test_import_is_silent_by_default(default_import):
+    """content_core must emit no log output of its own on import."""
+    assert default_import.returncode == 0, default_import.stderr
+    assert default_import.stdout == ""
+    for line in default_import.stderr.splitlines():
+        assert "content_core" not in line, f"leaked library log line: {line!r}"
+
+
+# Exercises real library code, which logs at DEBUG from inside the
+# content_core namespace — loguru's enable/disable keys off the record's module,
+# so the log call must genuinely originate inside the package.
+DO_WORK = (
+    "import asyncio\n"
+    "asyncio.run(content_core.extract(content='plain text'))\n"
+)
+# Marker: the DEBUG line content_core.processors.text emits for plain text.
+LIBRARY_LOG = "No HTML detected"
+
+
+def test_library_logs_are_disabled_by_default():
+    """Log calls from inside the content_core namespace stay silent."""
+    proc = run_host_app(extra=DO_WORK)
+    assert proc.returncode == 0, proc.stderr
+    assert LIBRARY_LOG not in proc.stderr
+
+
+def test_configure_logging_enables_library_logs():
+    """After the app calls configure_logging(), library logs appear again."""
+    proc = run_host_app(extra="content_core.configure_logging(debug=True)\n" + DO_WORK)
+    assert proc.returncode == 0, proc.stderr
+    # Once via the host sink, once via the sink configure_logging added.
+    assert proc.stderr.count(LIBRARY_LOG) == 2, proc.stderr
+    # The host's own handler must still be alive alongside it.
+    assert "HOST_DEBUG_SURVIVES" in proc.stderr
+
+
+def test_configure_logging_does_not_duplicate_output():
+    """Repeat calls must not stack sinks and double every line."""
+    proc = run_host_app(
+        extra="content_core.configure_logging(debug=True)\n" * 2 + DO_WORK
+    )
+    assert proc.returncode == 0, proc.stderr
+    # Once from the host's DEBUG sink, once from configure_logging's sink —
+    # the second configure_logging call must have replaced the first's sink.
+    assert proc.stderr.count(LIBRARY_LOG) == 2, proc.stderr
+
+
+def test_mcp_server_import_does_not_configure_logging():
+    """Importing the MCP server module must not reconfigure logging either."""
+    proc = run_host_app(extra="import content_core.mcp.server  # noqa: F401\n")
+    assert proc.returncode == 0, proc.stderr
+    assert "HOST_DEBUG_SURVIVES" in proc.stderr
+    assert proc.stdout == "", f"MCP import wrote to stdout: {proc.stdout!r}"


### PR DESCRIPTION
## Problem

`content_core` reconfigured loguru's process-wide singleton at **import time** — `logger.remove()` + `logger.add(sys.stderr, level="INFO")` in both `logging.py` and `mcp/server.py`. Importing the library nuked the host application's handlers and silently dropped its DEBUG logs. Reported downstream at lfnovo/open-notebook#1163.

## Change

Adopts loguru's sanctioned library pattern — libraries stay silent, applications configure.

- **`__init__.py`** — `logger.disable("content_core")` replaces the auto `configure_logging()` call. `configure_logging` stays importable/exported, so no import break for existing users.
- **`logging.py`** — `configure_logging(debug=False)` no longer does a blanket `logger.remove()`. It enables the `content_core` namespace and adds a stderr sink, using `LOGURU_LEVEL` as the default level when `debug=False`. It only drops loguru's own auto-added default sink (id 0, already gone once the host has called `remove()`) plus any sink a previous call added — so repeat calls don't stack sinks and the host's handlers always survive. The module-level auto-configuration is gone.
- **`mcp/server.py`** — the `remove()`/`add()` pair is out of the import path and now lives in `main()`, before `mcp.run()`. stderr only, so nothing contaminates the stdout JSON-RPC stream.
- **`cli.py`** — always calls `configure_logging(debug=debug)`, not just under `--debug`. The CLI is an application, so it is entitled to configure logging; without this it would go mute under the new `disable`.

## Tests

New `tests/unit/test_logging.py` (6 tests). Each scenario runs in a **subprocess** — loguru's `logger` is a process-wide singleton, so in-process tests would leak handler state across the suite. Covers: host handler survives import, import is silent, library logs disabled by default, `configure_logging()` re-enables them, repeat calls don't duplicate output, and importing the MCP server writes nothing to stdout.

## Validation

- `uv run pytest tests/unit tests/integration -v` — 298 passed
- Host-config survival: `HOST DEBUG SURVIVES` printed, zero `content_core` leakage
- `content-core extract tests/input_content/file.txt` — logs normally
- MCP stdio handshake — server answers `initialize`; stdout contains exactly 1 line (the JSON-RPC response), no log contamination

Closes #47

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

