### PR TITLE
ci: publish the wheel the packaging gate validated

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,12 +4,22 @@ name: Package
 # surfaces (library, CLI, MCP server) from the built artifact, with the repo
 # off the path. Called by test.yml (PRs / main) and by publish.yml (tags), so
 # a tag can never publish an artifact that failed this gate.
+#
+# The validated dist/ is uploaded as an artifact so publish.yml can release the
+# exact files this gate checked, instead of rebuilding on another runner.
 on:
   workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded artifact holding the validated dist/"
+        value: ${{ jobs.package.outputs.artifact-name }}
 
 jobs:
   package:
     runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.artifact.outputs.name }}
 
     steps:
     - uses: actions/checkout@v4
@@ -21,6 +31,12 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
+
+    # Unique per run attempt: upload-artifact@v4 rejects a duplicate name within
+    # a run, which would otherwise break "re-run failed jobs".
+    - name: Compute artifact name
+      id: artifact
+      run: echo "name=dist-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
     - name: Build wheel and sdist
       run: |
@@ -117,3 +133,14 @@ jobs:
             sys.exit(f"wheel version {match.group(1)!r} != pyproject version {expected!r}")
         print(f"version match OK: {expected}")
         PY
+
+    # Publish.yml downloads this instead of rebuilding, so the released files
+    # are byte-for-byte the ones validated above. On PR runs it is just an
+    # unused short-lived upload.
+    - name: Upload validated dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.artifact.outputs.name }}
+        path: dist/
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,32 +10,44 @@ jobs:
   package:
     uses: ./.github/workflows/package.yml
 
+  # Publishes the exact artifact the packaging gate validated - it is downloaded
+  # from the package job rather than rebuilt here, so a green gate always covers
+  # the files that reach PyPI (uploads are immutable, a rebuild could differ).
   publish:
     needs: package
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v4
-    
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-        
-    - name: Install dependencies and build tools
-      run: |
-        uv venv
-        rm -rf dist
-        uv sync
 
-    - name: Build package
-      run: uv build
-    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Download validated dist
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.package.outputs.artifact-name }}
+        path: dist
+
+    - name: Verify downloaded dist
+      run: |
+        set -euo pipefail
+        ls -la dist/
+        python - <<'PY'
+        import glob, sys
+
+        wheels = glob.glob("dist/content_core-*.whl")
+        sdists = glob.glob("dist/content_core-*.tar.gz")
+        if len(wheels) != 1:
+            sys.exit(f"expected exactly one wheel in dist/, got {wheels}")
+        if len(sdists) != 1:
+            sys.exit(f"expected exactly one sdist in dist/, got {sdists}")
+        print("dist/ OK:", wheels + sdists)
+        PY
+
     - name: Publish to PyPI
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ uv sync --group dev
 uv run pytest tests/unit tests/integration -v
 ```
 
-This is the gate. It returns clean pass/fail in ~15s, requires no credentials or network, and matches what CI enforces on `main` (CI runs only `tests/unit`; integration tests are also safe locally — no network/API keys). For targeted feedback during iteration, use `uv run pytest -k "<keyword>"` per the table in the Testing section below.
+This is the gate. It returns clean pass/fail in ~15s and requires no credentials or network. CI on PRs and `main` runs exactly these tests (`tests/unit tests/integration`) across Python 3.10/3.11/3.12, plus a packaging gate (`.github/workflows/package.yml`) that builds the wheel and exercises the library, the `content-core` CLI and the `content-core-mcp` server from the built artifact. The packaging gate needs no credentials either, but it is not reproducible from a plain pytest run — if you touch packaging metadata (`pyproject.toml`, entry points, package data), expect it to be the check that catches you. For targeted feedback during iteration, use `uv run pytest -k "<keyword>"` per the table in the Testing section below.
 
 ### Do NOT use as gates
 


### PR DESCRIPTION
Follow-up to #54, closing the two cubic findings that were left open when it merged.

## 1. P2 — `publish.yml` published a different wheel than the gate validated

The `package` and `publish` jobs each ran their own `uv build`, on different
runners. A green packaging gate therefore said nothing about the artifact that
actually reached PyPI — which was the entire point of #48. PyPI uploads are
immutable, so a divergent rebuild burns the version permanently.

- `package.yml` now uploads the validated `dist/` via `actions/upload-artifact`
  (`if-no-files-found: error`) and exposes the artifact name as a
  `workflow_call` output.
- `publish.yml` drops its `checkout` / `uv sync` / `uv build` and instead
  `actions/download-artifact`s that exact artifact into `dist/`, then
  `uv publish`es it.

Two details:

- **No collisions on PR runs.** `package.yml` is also called by `test.yml` on
  every PR, where the upload is simply unused. The artifact name is
  `dist-<run_id>-<run_attempt>`, unique per run *and* per attempt —
  `upload-artifact@v4` rejects a duplicate name within a run, which would
  otherwise break "re-run failed jobs". Retention is 1 day so PR runs do not
  accumulate storage. `publish` reads the name from the `package` job output
  rather than recomputing it, so a re-run of only the failed `publish` job
  still resolves the name of the artifact the earlier attempt uploaded.
- **Fails loudly on an empty download.** A `Verify downloaded dist` step
  asserts `dist/` contains exactly one wheel and exactly one sdist and exits
  non-zero otherwise, so a missing or empty artifact aborts the release
  instead of silently publishing nothing.

## 2. P3 — `CLAUDE.md` misstated CI coverage

The "Validator command" paragraph still claimed *"CI runs only `tests/unit`"*.
It now describes what CI actually runs: `tests/unit tests/integration` across
Python 3.10/3.11/3.12, plus the packaging gate, with a note that the packaging
gate is not reproducible from a plain pytest run and is the check that catches
packaging-metadata changes. Tone and structure of the section are unchanged.

## Testing

- `uv run pytest tests/unit tests/integration -v` — 292 passed.
- All three workflows parse as YAML (`actionlint` not available locally).
- Every packaging-gate step re-run locally against a fresh `rm -rf dist && uv build`:
  asset check (`content_core/py.typed` present), public API import from the
  wheel, `content-core --help`, `content-core extract`, MCP `initialize`
  handshake (`serverInfo` returned). The new `Verify downloaded dist` script
  was run against the same `dist/` and passes.
- Artifact hand-off reviewed end to end: `publish needs: package`, name flows
  `steps.artifact.outputs.name` → job output → `needs.package.outputs.artifact-name`,
  upload `path: dist/` → download `path: dist`, and `uv publish` defaults to
  `dist/*`, which is exactly what the gate validated.
- `cubic review` on the local diff: no issues.

The tag-push path itself cannot be exercised before a release; the checks above
are the closest available substitute.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

