### PR TITLE
deps: drop unused asciidoc dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "readability-lxml>=0.8.4.1",
     "firecrawl-py>=4.13.0",
     "pillow>=12.0.0",
-    "asciidoc>=10.2.1",
     "pytubefix>=10.0.0",
     "fastmcp>=3.0.0",
     "tenacity>=9.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -289,15 +289,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asciidoc"
-version = "10.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/e7/315a82f2d256e9270977aa3c15e8fe281fd7c40b8e2a0b97e0cb61ca8fa0/asciidoc-10.2.1.tar.gz", hash = "sha256:d9f13c285981b3c7eb660d02ca0a2779981e88d48105de81bb40445e60dddb83", size = 230179, upload-time = "2024-07-17T03:12:52.681Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/1f/87941eaa96e86aa22086064f67e4187e2710fb76c147312979ea29278dac/asciidoc-10.2.1-py2.py3-none-any.whl", hash = "sha256:3f277a636b617c9ce7e0b87bcaea51f144500e9a5c8a6488421ee24594850d40", size = 272433, upload-time = "2024-07-17T03:12:49.012Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -780,7 +771,6 @@ source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },
     { name = "aiohttp" },
-    { name = "asciidoc" },
     { name = "bs4" },
     { name = "click" },
     { name = "esperanto" },
@@ -839,7 +829,6 @@ dev = [
 requires-dist = [
     { name = "ai-prompter", specifier = ">=0.4.0" },
     { name = "aiohttp", specifier = ">=3.13" },
-    { name = "asciidoc", specifier = ">=10.2.1" },
     { name = "bs4", specifier = ">=0.0.2" },
     { name = "click", specifier = ">=8.3.0" },
     { name = "crawl4ai", marker = "extra == 'crawl4ai'", specifier = ">=0.7.0" },


### PR DESCRIPTION
`asciidoc` is declared as a required dependency but is never imported or
referenced anywhere in `src/`.

I ran into this while auditing licences downstream (Open Notebook), and it
looked like it might be load-bearing — so I checked carefully before proposing
removal.

## Why it appears unused

- **No reference anywhere under `src/`** — `grep -rni asciidoc src/` returns nothing.
- The only non-lockfile mentions are in `docs/processors.md` and `docs/usage.md`,
  and both describe **Docling's** format support ("Docling provides advanced
  document parsing for PDF, DOCX, PPTX, XLSX, Markdown, AsciiDoc, HTML, CSV,
  and images"). Docling handles AsciiDoc input itself, so the `asciidoc` PyPI
  package isn't what provides that capability.

My guess is it was added on the assumption that AsciiDoc *file* support needed
it. If that's wrong and it's reserved for planned work, happy to close this —
or convert it to an optional extra instead (see below).

## Verification

- **`tests/unit` passes with `asciidoc` uninstalled**: `270 passed`.
- **Extraction output is byte-identical** with and without it across `txt`,
  `md`, `csv`, `docx`, `pptx`, `xlsx`, `epub`, inline HTML, and a real
  55,493-character PDF — same character count, same extracted text.
- After removing it from `pyproject.toml` and re-locking, a clean `uv sync`
  followed by `tests/unit` passes.

The only failures I saw in any run were in
`tests/unit/test_file_detector_performance.py`, and they're timing-sensitive:
across four runs they produced 3, 0, 1 and 1 failures on *different* tests,
both with and without `asciidoc` installed. They look unrelated to this change
(and likely just my machine).

## Why it's worth removing

Beyond being ~272 KB of dead weight: `asciidoc` is **GPLv2+**, while the rest
of the dependency tree is MIT/Apache-2.0. That one copyleft dependency creates
redistribution obligations for anyone shipping content-core inside a
commercially distributed artifact — for no functionality in return.

## Alternative

If you'd rather keep an escape hatch, I'm glad to change this to an optional
extra instead, matching the existing `docling` / `crawl4ai` / `langchain`
pattern:

```toml
[project.optional-dependencies]
asciidoc = ["asciidoc>=10.2.1"]
```

That solves the default-install licence issue while keeping it one `pip install
content-core[asciidoc]` away. Just say which you prefer.

Thanks for content-core — it's doing a lot of heavy lifting for us.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

