### PR TITLE
feat: publish agent skill as a Claude Code and Codex plugin marketplace

### DIFF
--- a/.agent-smith/index.json
+++ b/.agent-smith/index.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": "2.0",
+  "topology": "marketplace",
+  "targets": ["claude", "codex"],
+  "canonicalPaths": {
+    "skills": "skills",
+    "index": ".agent-smith/index.json"
+  },
+  "lastUpdated": "2026-07-22T00:00:00Z",
+  "components": [
+    {
+      "id": "skill:content-core",
+      "type": "skill",
+      "name": "content-core",
+      "canonicalPath": "skills/content-core/SKILL.md",
+      "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files"
+    }
+  ],
+  "adapters": [
+    {
+      "componentId": "skill:content-core",
+      "harness": "claude",
+      "status": "shared",
+      "path": "skills/content-core/SKILL.md",
+      "sourcePath": "skills/content-core"
+    },
+    {
+      "componentId": "skill:content-core",
+      "harness": "codex",
+      "status": "shared",
+      "path": "skills/content-core/SKILL.md",
+      "sourcePath": "skills/content-core"
+    }
+  ],
+  "gaps": [],
+  "marketplaces": [
+    {
+      "harness": "claude",
+      "manifestPath": ".claude-plugin/marketplace.json",
+      "plugins": [
+        {
+          "name": "content-core",
+          "sourceType": "local",
+          "path": ".",
+          "managed": true
+        }
+      ]
+    },
+    {
+      "harness": "codex",
+      "manifestPath": ".agents/plugins/marketplace.json",
+      "plugins": [
+        {
+          "name": "content-core",
+          "sourceType": "local",
+          "path": ".",
+          "managed": true
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "content-core",
+  "plugins": [
+    {
+      "name": "content-core",
+      "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "category": "development",
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,10 +4,8 @@
     "name": "Luis Novo",
     "email": "lfnovo@gmail.com"
   },
-  "metadata": {
-    "description": "Content Core — content extraction toolkit for AI agents",
-    "version": "1.0.0"
-  },
+  "description": "Content Core — content extraction toolkit for AI agents",
+  "version": "1.0.0",
   "plugins": [
     {
       "name": "content-core",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "content-core",
+  "owner": {
+    "name": "Luis Novo",
+    "email": "lfnovo@gmail.com"
+  },
+  "metadata": {
+    "description": "Content Core — content extraction toolkit for AI agents",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "content-core",
+      "source": "./",
+      "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
+      "category": "development",
+      "keywords": ["extraction", "content", "pdf", "youtube", "transcription", "mcp"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "content-core",
+  "version": "2.0.4",
+  "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
+  "author": {
+    "name": "Luis Novo",
+    "email": "lfnovo@gmail.com"
+  },
+  "homepage": "https://github.com/lfnovo/content-core",
+  "repository": "https://github.com/lfnovo/content-core",
+  "license": "MIT",
+  "keywords": ["extraction", "content", "pdf", "youtube", "transcription", "mcp"]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "content-core",
+  "version": "2.0.4",
+  "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
+  "skills": "./skills/"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Plugin marketplace support for Claude Code and Codex: the repository now carries `.claude-plugin/` (plugin + marketplace manifests) and `.codex-plugin/` + `.agents/plugins/` manifests, so the agent skill installs natively via `/plugin marketplace add lfnovo/content-core` (Claude Code) or the Codex catalog
+- Plugin marketplace support for Claude Code and Codex: the repository now carries `.claude-plugin/` (plugin + marketplace manifests) and `.codex-plugin/` + `.agents/plugins/` manifests, so the agent skill installs natively via `/plugin marketplace add lfnovo/content-core` (Claude Code) or via the Codex marketplace catalog
 
 ### Changed
 - Agent skill moved from the repository root (`SKILL.md`) to `skills/content-core/SKILL.md` and refreshed: Reddit capability documented, YouTube `live`/`shorts` URL forms, portable frontmatter, `--version`, updated model examples. The old raw-file URL no longer resolves — the README documents the new path and the marketplace install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Plugin marketplace support for Claude Code and Codex: the repository now carries `.claude-plugin/` (plugin + marketplace manifests) and `.codex-plugin/` + `.agents/plugins/` manifests, so the agent skill installs natively via `/plugin marketplace add lfnovo/content-core` (Claude Code) or the Codex catalog
+
+### Changed
+- Agent skill moved from the repository root (`SKILL.md`) to `skills/content-core/SKILL.md` and refreshed: Reddit capability documented, YouTube `live`/`shorts` URL forms, portable frontmatter, `--version`, updated model examples. The old raw-file URL no longer resolves — the README documents the new path and the marketplace install
+
 ## [2.0.4] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ content-core mcp
 ```bash
 # Set persistent config
 content-core config set llm_provider anthropic
-content-core config set llm_model claude-sonnet-4-20250514
+content-core config set llm_model claude-sonnet-5
 
 # List current config
 content-core config list
@@ -177,17 +177,27 @@ The MCP server exposes two tools: `extract_content` and `summarize_content`. Bot
 
 For detailed setup, see the [MCP documentation](docs/mcp.md).
 
-## Claude Code Skill
+## Agent Skill (Claude Code & Codex)
 
-Content Core includes a [`SKILL.md`](SKILL.md) that teaches AI agents how to use it for extracting content from external sources. To make it available in your Claude Code project, copy it to your skills directory:
+Content Core ships an [Agent Skill](skills/content-core/SKILL.md) that teaches AI agents how to use it for extracting content from external sources. This repository is also a plugin marketplace, so the skill installs natively in both harnesses.
 
-```bash
-# Download the skill
-curl -o .claude/skills/content-core/SKILL.md --create-dirs \
-  https://raw.githubusercontent.com/lfnovo/content-core/main/SKILL.md
+**Claude Code** — add the marketplace and install the plugin:
+
+```
+/plugin marketplace add lfnovo/content-core
+/plugin install content-core@content-core
 ```
 
-Once installed, Claude Code can use content-core to extract content from URLs, documents, and media files — either via CLI (`uvx content-core`) or MCP if configured.
+**Codex** — the repository carries a Codex plugin manifest (`.codex-plugin/plugin.json`) and marketplace catalog (`.agents/plugins/marketplace.json`) pointing at the same skill.
+
+**Manual fallback** — copy the skill file directly into your project:
+
+```bash
+curl -o .claude/skills/content-core/SKILL.md --create-dirs \
+  https://raw.githubusercontent.com/lfnovo/content-core/main/skills/content-core/SKILL.md
+```
+
+Once installed, the agent can use content-core to extract content from URLs, documents, and media files — either via CLI (`uvx content-core`) or MCP if configured.
 
 ## AI Providers
 
@@ -196,7 +206,7 @@ Content Core uses [Esperanto](https://github.com/lfnovo/esperanto) to support mu
 ```bash
 # Use Anthropic for summarization
 content-core config set llm_provider anthropic
-content-core config set llm_model claude-sonnet-4-20250514
+content-core config set llm_model claude-sonnet-5
 
 # Use Groq for transcription
 content-core config set stt_provider groq

--- a/skills/content-core/SKILL.md
+++ b/skills/content-core/SKILL.md
@@ -1,18 +1,14 @@
 ---
 name: content-core
 description: >
-  Extract text content from external sources — URLs, PDFs, documents, YouTube videos, and audio/video files.
-  Use when you need to read, analyze, or summarize content from a URL, file, or media source.
-allowed-tools:
-  - Read
-  - Bash
-  - Grep
-  - Glob
+  Extract text content from external sources — URLs, PDFs, documents, YouTube videos,
+  Reddit posts, and audio/video files. Use when you need to read, analyze, or summarize
+  content from a URL, file, or media source.
 ---
 
 ## Purpose
 
-Content Core extracts text from external sources so you can read, analyze, or summarize them. Use it whenever you need content from a URL, PDF, document, YouTube video, or audio/video file.
+Content Core extracts text from external sources so you can read, analyze, or summarize them. Use it whenever you need content from a URL, PDF, document, YouTube video, Reddit post, or audio/video file.
 
 Most extraction works without API keys. Only audio/video transcription and summarization require an LLM API key (e.g., `OPENAI_API_KEY`).
 
@@ -40,7 +36,8 @@ After installation, the user may need to restart their shell or run `source ~/.b
 | Source | Examples | API Key Needed |
 |--------|----------|----------------|
 | Web pages | Any URL | No |
-| YouTube | Video transcript | No |
+| YouTube | Video transcript (`watch`, `live`, `shorts` URLs) | No |
+| Reddit | Post + comments via public JSON | No |
 | Documents | PDF, DOCX, PPTX, XLSX, EPUB, Markdown | No |
 | Audio | MP3, WAV, M4A, FLAC, OGG | Yes (STT) |
 | Video | MP4, AVI, MOV, MKV | Yes (STT) |
@@ -49,6 +46,11 @@ After installation, the user may need to restart their shell or run `source ~/.b
 ## CLI Usage
 
 All commands use `uvx content-core` which runs without installation.
+
+```bash
+# Check the installed version
+uvx content-core --version
+```
 
 ### Extract content
 
@@ -59,8 +61,11 @@ uvx content-core extract "https://example.com"
 # From a file
 uvx content-core extract document.pdf
 
-# From a YouTube video
+# From a YouTube video (watch, live, and shorts URLs all work)
 uvx content-core extract "https://www.youtube.com/watch?v=VIDEO_ID"
+
+# From a Reddit post
+uvx content-core extract "https://www.reddit.com/r/sub/comments/POST_ID/title/"
 
 # JSON output (includes title, content, metadata)
 uvx content-core extract --format json "https://example.com"
@@ -106,7 +111,7 @@ uvx content-core config list
 
 # Set persistent defaults
 uvx content-core config set llm_provider anthropic
-uvx content-core config set llm_model claude-sonnet-4-20250514
+uvx content-core config set llm_model claude-sonnet-5
 uvx content-core config set url_engine firecrawl
 
 # Delete a config value
@@ -133,7 +138,7 @@ extract_content(url="https://example.com")
 extract_content(file_path="/path/to/document.pdf")
 extract_content(url="https://youtube.com/watch?v=ID")
 
-# With engine override
+# With engine override (firecrawl, jina, crawl4ai, simple, docling)
 extract_content(file_path="paper.pdf", engine="docling")
 
 # With Docling enrichment
@@ -153,8 +158,8 @@ If summarization fails with an API key error, fall back to `extract_content` and
 ## Guidelines
 
 - For small/medium content (articles, short pages): prefer MCP tools if available — they are async and more efficient
-- For large content (long documents, full books, lengthy transcripts): prefer the CLI via Bash, redirecting output to a file (`uvx content-core extract "URL" > output.md`). This avoids flooding the agent's context window with large payloads. Read only the relevant sections from the file as needed.
-- If MCP is not available, always use the CLI via Bash with `uvx content-core`
+- For large content (long documents, full books, lengthy transcripts): prefer the CLI via a shell, redirecting output to a file (`uvx content-core extract "URL" > output.md`). This avoids flooding the agent's context window with large payloads. Read only the relevant sections from the file as needed.
+- If MCP is not available, always use the CLI via a shell with `uvx content-core`
 - For URLs: extraction works without any API key
 - For audio/video: requires `OPENAI_API_KEY` (or another STT provider key)
 - For summarization: requires an LLM API key


### PR DESCRIPTION
Turns the repository into an installable plugin marketplace for Claude Code and Codex, and refreshes the agent skill that was previously published as a root-level `SKILL.md` installed via `curl`.

## Marketplace format

- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — enables `/plugin marketplace add lfnovo/content-core` followed by `/plugin install content-core@content-core`
- `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json` — Codex manifest and catalog pointing at the **same** `skills/` tree (no copies)
- `.agent-smith/index.json` — component index (topology: marketplace; targets: claude, codex; no compatibility gaps)

## Skill refresh (`skills/content-core/SKILL.md`)

- Adds the missing **Reddit** capability (post + comments, no API key)
- Documents YouTube `watch`/`live`/`shorts` URL forms (2.0.4 fix) and the `--version` flag (2.0.3)
- Portable frontmatter (`name` + `description` only; drops the experimental `allowed-tools` field so the same file is valid in both harnesses)
- Updates stale model examples

## Breaking distribution change

The root `SKILL.md` is removed — the old raw-file curl URL no longer resolves. The README now documents the marketplace install for both harnesses plus the curl fallback at the new path. CHANGELOG entry included under Unreleased.

## Test plan

- `agent-smith` structural validator: 0 errors (2 plugin manifests, marketplace entry resolved for both targets, 1 shared skill, index v2)
- No Python code touched; unit/integration suites unaffected
- Harness-native install smoke test not run (requires the published repo); can be verified post-merge with a local-path marketplace add


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

