### PR TITLE
fix/issue-59-title

### DIFF
--- a/src/content_core/processors/text.py
+++ b/src/content_core/processors/text.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import re
 
 from markdownify import markdownify as md
@@ -31,6 +32,21 @@ def detect_html(content: str) -> bool:
     """
     matches = HTML_STRUCTURAL_TAGS.findall(content)
     return len(matches) >= HTML_DETECTION_THRESHOLD
+
+
+TITLE_RE = re.compile(
+    r"<title[^>]*>(.*?)</title>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def extract_html_title(content: str) -> str:
+    """Extract the HTML document title."""
+    match = TITLE_RE.search(content)
+    if not match:
+        return ""
+
+    return html.unescape(match.group(1)).strip()
 
 
 async def extract_text_file(file_path: str, config: ContentCoreConfig) -> ExtractionOutput:
@@ -66,9 +82,11 @@ async def process_text(content: str, config: ContentCoreConfig) -> ExtractionOut
     if detect_html(content):
         logger.debug("HTML detected in content, converting to markdown")
         try:
+            title = extract_html_title(content)
             converted = md(content, heading_style="ATX", bullets="-")
             return ExtractionOutput(
                 content=converted,
+                title=title,
                 source_type="text",
                 identified_type="text/plain",
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->

#### Partial Fix #59: HTML title extraction

#### Summary

This PR implements the HTML title extraction portion of Issue #59... 
During HTML processing by populating `ExtractionOutput.title` from the document's `<title>` element.

When an HTML document contains a `<title>` element, it is used as the source title. If no `<title>` element is present, the existing filename fallback behavior is preserved.

HTML entities within the title (such as `&amp;` or `&#39;`) are decoded before being stored.

Changes included:
- Extract the HTML `<title>` element when processing HTML content.
- Populate `ExtractionOutput.title` with the extracted value.
- Decode HTML entities before storing the title.
- Preserve the existing filename fallback when no `<title>` element is present.

This improves source naming for HTML documents while maintaining backward compatibility for documents without a title.

#### Tested with HTML documents both containing and lacking a `<title>` element.

- Documents with a `<title>` now use the document title as the source name.
- Documents without a `<title>` continue using the uploaded filename.

This PR implements the title extraction portion of Issue #59. The HTML file routing support is submitted separately.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

