### PR TITLE
Partial Fix #59: Add support for local HTML file ingestion

### DIFF
--- a/src/content_core/extraction.py
+++ b/src/content_core/extraction.py
@@ -132,7 +132,7 @@ def _route_for_mime(mime: str, cfg: ContentCoreConfig) -> str | None:
         return "video"
     if mime.startswith("audio/"):
         return "audio"
-    if mime == "text/plain":
+    if mime in ("text/plain", "text/html"):
         return "text"
     return None
 

--- a/src/content_core/processors/text.py
+++ b/src/content_core/processors/text.py
@@ -43,11 +43,9 @@ async def extract_text_file(file_path: str, config: ContentCoreConfig) -> Extrac
     try:
         content = await asyncio.get_event_loop().run_in_executor(None, _read_file)
         logger.debug(f"Extracted text from {file_path}: {content[:100]}")
-        return ExtractionOutput(
-            content=content,
-            source_type="file",
-            identified_type="text/plain",
-        )
+        result = await process_text(content, config)
+        result.source_type = "file"
+        return result
     except FileNotFoundError:
         raise FileNotFoundError(f"File not found at {file_path}")
     except Exception as e:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->


#### Summary

This PR implements the HTML file routing portion of Issue #59 by enabling local HTML files to be processed through the existing text processor.

Previously, HTML files were identified as `text/html` but were not routed to the text processor unless Docling was installed. This change routes local HTML files through the existing processing pipeline, allowing them to reuse the existing HTML detection and HTML-to-Markdown conversion logic without introducing a separate HTML processor.

Changes included:
- Route `text/html` files to the text processor.
- Reuse the existing HTML detection logic.
- Reuse the existing HTML-to-Markdown conversion.
- Preserve the existing behavior for plain text files.

#### Tested with a variety of HTML files.

- Local HTML files are now accepted without requiring Docling.
- HTML content is converted to Markdown using the existing processing pipeline.
- Plain `.txt` extraction behavior remains unchanged.

This PR implements the HTML file routing portion of Issue #59. HTML `<title>` extraction is submitted separately.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

