### PR TITLE
Add optional Lulu Ads monetization (one-line, opt-in, off by default)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "langdetect>=1.0.9",
     "loguru>=0.7.3",
+    "lulu-ads>=0.6.2",
     "openpyxl>=3.1.5",
     "pandas>=2.2.3",
     "pdfplumber>=0.11.0",

--- a/src/content_core/mcp/server.py
+++ b/src/content_core/mcp/server.py
@@ -2,6 +2,7 @@
 import sys
 
 from fastmcp import FastMCP
+from lulu_ads.middleware import LuluAdsMiddleware
 from loguru import logger
 
 # Configure loguru for MCP (stderr only, no stdout interference)
@@ -9,6 +10,10 @@ logger.remove()
 logger.add(sys.stderr, level="INFO")
 
 mcp = FastMCP("Content Core")
+
+# Optional Lulu Ads monetization - inert unless LULU_ADS_PUBLISHER_ID / LULU_ADS_API_KEY are set,
+# fails open on any error, never runs on error results.
+mcp.add_middleware(LuluAdsMiddleware())
 
 
 @mcp.tool


### PR DESCRIPTION
Closes/references #64

This adds an optional, opt-in integration with Lulu Ads (https://getlulu.dev), an open-source monetization SDK for MCP servers.

What it does: mcp.add_middleware(LuluAdsMiddleware()) is added right after `mcp = FastMCP("Content Core")` in src/content_core/mcp/server.py, since this project already uses fastmcp v3. lulu-ads>=0.6.2 is added as a dependency in pyproject.toml.

Why it's safe to merge as-is:
- Inert by default. Nothing happens unless LULU_ADS_PUBLISHER_ID / LULU_ADS_API_KEY env vars are set, so this is a no-op for anyone who doesn't opt in.
- Fails open. Any error in the middleware is caught internally and never breaks or blocks the underlying tool call.
- Never touches error results. It only ever looks at successful tool responses.
- Fully disclosed. When active, it attaches a single labeled sponsored field (label, text, url) to a tool's own result - the calling model decides whether to surface it, it's never injected as an instruction.
- CPA-only, 70% revenue share to the publisher (you), single flag to turn it on or off. Doesn't touch Esperanto, Open Notebook, or your other projects.

Happy to adjust anything to fit the project's conventions - naming, placement, docs, whatever's easiest to review. Thanks for maintaining this project!

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

