### PR TITLE
fix: detect Ogg/Opus audio and keep source container when splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Agent skill moved from the repository root (`SKILL.md`) to `skills/content-core/SKILL.md` and refreshed: Reddit capability documented, YouTube `live`/`shorts` URL forms, portable frontmatter, `--version`, updated model examples. The old raw-file URL no longer resolves — the README documents the new path and the marketplace install
+- Minimum `esperanto` version raised to 2.26.0, which fixes every non-Whisper OpenAI and Azure transcription model: `verbose_json` was requested for anything that didn't match a narrow `gpt-4o-*-transcribe` name shape, so `gpt-transcribe` and friends failed before transcription started
+
+### Fixed
+- `.opus` files (the common export format for WhatsApp voice messages) raised `UnsupportedTypeException` instead of being transcribed — the extension was missing from the MIME mapping, and the Ogg container had no magic-byte signature at all. Ogg files are now detected by content as well as extension, with Opus/Vorbis/FLAC routed to audio and Theora to video
+- Audio longer than 10 minutes failed for any non-MP3 source, including the already-supported `.flac` and `.ogg`: segments were stream-copied but named `.mp3`, so ffmpeg refused to mux them. Segments now keep the source container
 
 ## [2.0.4] - 2026-07-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.13",
     "bs4>=0.0.2",
-    "esperanto>=2.20.1",
+    "esperanto>=2.26.0",
     "jinja2>=3.1.6",
     "langdetect>=1.0.9",
     "loguru>=0.7.3",

--- a/src/content_core/content/identification/file_detector.py
+++ b/src/content_core/content/identification/file_detector.py
@@ -59,6 +59,7 @@ class FileDetector:
             b'\xff\xf2': 'audio/mpeg',  # MP3 frame sync with MPEG-2.5 Layer 3
             b'RIFF': None,  # Resource Interchange File Format - requires further inspection (could be WAV, AVI, WebP)
             b'fLaC': 'audio/flac',  # Free Lossless Audio Codec signature
+            b'OggS': None,  # Ogg container - requires further inspection (Opus/Vorbis/FLAC audio, or Theora video)
             
             # Video/Audio containers - these will be handled by ftyp detection
             # MP4/M4A/MOV use ftyp box at offset 4 for identification
@@ -126,6 +127,7 @@ class FileDetector:
             '.aac': 'audio/aac',
             '.ogg': 'audio/ogg',
             '.oga': 'audio/ogg',
+            '.opus': 'audio/ogg',
             '.flac': 'audio/flac',
             '.wma': 'audio/x-ms-wma',
             
@@ -231,6 +233,12 @@ class FileDetector:
                         elif header[8:12] == b'AVI ':
                             return 'video/x-msvideo'
                     
+                    # Special handling for Ogg (audio and video share the container)
+                    if signature == b'OggS':
+                        ogg_mime = self._detect_ogg_codec(header)
+                        if ogg_mime:
+                            return ogg_mime
+
                     # Special handling for ZIP-based formats
                     if mime_type == 'application/zip':
                         zip_mime = await self._detect_zip_format(file_path)
@@ -260,6 +268,20 @@ class FileDetector:
             logger.debug(f"Error reading file signature: {e}")
             return None
     
+    def _detect_ogg_codec(self, header: bytes) -> Optional[str]:
+        """Disambiguate an Ogg container by the codec identification header.
+
+        The codec id lives in the first page's payload, well within the bytes
+        already read for signature detection. Theora is checked first because a
+        video stream is usually multiplexed with a Vorbis audio track, and the
+        file should route to the video pipeline in that case.
+        """
+        if b'theora' in header:
+            return 'video/ogg'
+        if b'OpusHead' in header or b'vorbis' in header or b'FLAC' in header:
+            return 'audio/ogg'
+        return None
+
     async def _detect_zip_format(self, file_path: Path) -> Optional[str]:
         """Detect specific ZIP-based format (DOCX, XLSX, PPTX, EPUB)."""
         try:

--- a/src/content_core/processors/media/audio.py
+++ b/src/content_core/processors/media/audio.py
@@ -80,11 +80,15 @@ async def split_audio(input_file, segment_length_minutes=15, output_prefix=None)
         total_segments = math.ceil(duration / segment_length_s)
         logger.debug(f"Splitting file: {input_file_abs} into {total_segments} segments")
 
+        # Segments are stream-copied, so they must keep the source container:
+        # muxing e.g. an Opus stream into a .mp3 output makes ffmpeg fail.
+        source_ext = os.path.splitext(input_file_abs)[1] or ".mp3"
+
         output_files = []
         for i in range(total_segments):
             start_time = i * segment_length_s
             end_time = min((i + 1) * segment_length_s, duration)
-            output_filename = f"{output_prefix}_{str(i + 1).zfill(3)}.mp3"
+            output_filename = f"{output_prefix}_{str(i + 1).zfill(3)}{source_ext}"
             output_path = os.path.join(output_dir, output_filename)
 
             split_audio_segment(input_file_abs, output_path, start_time, end_time)
@@ -146,6 +150,10 @@ async def transcribe_audio(file_path: str, config: ContentCoreConfig) -> Extract
             segment_length_s = 10 * 60
             output_files = []
 
+            # Segments are stream-copied, so they must keep the source container:
+            # muxing e.g. an Opus stream into a .mp3 output makes ffmpeg fail.
+            source_ext = os.path.splitext(file_path)[1] or ".mp3"
+
             if duration_s > segment_length_s:
                 logger.info(
                     f"Audio is longer than 10 minutes ({duration_s:.0f}s), splitting into "
@@ -155,7 +163,7 @@ async def transcribe_audio(file_path: str, config: ContentCoreConfig) -> Extract
                 for i in range(math.ceil(duration_s / segment_length_s)):
                     start_time = i * segment_length_s
                     end_time = min((i + 1) * segment_length_s, duration_s)
-                    output_filename = f"{output_prefix}_{str(i + 1).zfill(3)}.mp3"
+                    output_filename = f"{output_prefix}_{str(i + 1).zfill(3)}{source_ext}"
                     output_path = os.path.join(temp_dir, output_filename)
                     await loop.run_in_executor(
                         None, partial(extract_audio, file_path, output_path, start_time, end_time)

--- a/tests/unit/test_file_detector.py
+++ b/tests/unit/test_file_detector.py
@@ -58,3 +58,66 @@ class TestFileDetectorPDF:
         # Should be fast (under 100ms for signature-based detection)
         detection_time = (end_time - start_time) * 1000  # Convert to ms
         assert detection_time < 100, f"PDF detection took {detection_time:.2f}ms, expected < 100ms"
+
+
+def _ogg_page(codec_id: bytes) -> bytes:
+    """Build a minimal Ogg page carrying a codec identification header.
+
+    Enough for signature detection, which only inspects the leading bytes.
+    """
+    page_header = (
+        b"OggS"           # capture pattern
+        + b"\x00"         # stream structure version
+        + b"\x02"         # header type: beginning of stream
+        + b"\x00" * 8     # granule position
+        + b"\x01\x00\x00\x00"  # bitstream serial number
+        + b"\x00" * 4     # page sequence number
+        + b"\x00" * 4     # checksum
+        + b"\x01"         # page segments
+        + b"\x1e"         # segment table
+    )
+    return page_header + codec_id + b"\x00" * 64
+
+
+class TestFileDetectorOgg:
+    """Ogg container detection: Opus, Vorbis and Theora share the same magic bytes."""
+
+    @pytest.fixture
+    def detector(self):
+        return FileDetector()
+
+    @pytest.mark.asyncio
+    async def test_detect_opus_by_signature(self, detector, tmp_path):
+        """An Ogg/Opus file is audio, detected from its codec header."""
+        opus_path = tmp_path / "voice_note.opus"
+        opus_path.write_bytes(_ogg_page(b"OpusHead"))
+
+        assert await detector.detect(str(opus_path)) == "audio/ogg"
+
+    @pytest.mark.asyncio
+    async def test_detect_opus_by_extension(self, detector, tmp_path):
+        """The .opus extension maps to audio/ogg even when sniffing finds nothing.
+
+        Regression: .opus was missing from the extension mapping, so these files
+        raised UnsupportedTypeException.
+        """
+        opus_path = tmp_path / "voice_note.opus"
+        opus_path.write_bytes(b"\x00" * 64)
+
+        assert await detector.detect(str(opus_path)) == "audio/ogg"
+
+    @pytest.mark.asyncio
+    async def test_detect_ogg_vorbis_still_audio(self, detector, tmp_path):
+        """Existing Ogg/Vorbis behavior is unchanged."""
+        ogg_path = tmp_path / "clip.ogg"
+        ogg_path.write_bytes(_ogg_page(b"\x01vorbis"))
+
+        assert await detector.detect(str(ogg_path)) == "audio/ogg"
+
+    @pytest.mark.asyncio
+    async def test_ogg_theora_routes_as_video(self, detector, tmp_path):
+        """Ogg video must not be mistaken for audio just by its container."""
+        ogv_path = tmp_path / "clip.ogv"
+        ogv_path.write_bytes(_ogg_page(b"\x80theora"))
+
+        assert await detector.detect(str(ogv_path)) == "video/ogg"

--- a/tests/unit/test_media_pipeline.py
+++ b/tests/unit/test_media_pipeline.py
@@ -153,6 +153,44 @@ class TestTranscribeAudio:
             assert result.metadata["segments_count"] == 3
             assert mock_extract.call_count == 3
 
+    async def test_split_segments_keep_source_extension(self):
+        """Segments are stream-copied, so the container must match the source.
+
+        Naming an Opus segment .mp3 makes ffmpeg refuse to mux it.
+        """
+        config = ContentCoreConfig(
+            stt_provider="openai",
+            stt_model="whisper-1",
+            audio_provider="openai",
+            audio_model=None,
+        )
+
+        mock_stt_model = MagicMock()
+        mock_result = MagicMock()
+        mock_result.text = "segment"
+        mock_stt_model.atranscribe = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("esperanto.AIFactory") as mock_factory,
+            patch(
+                "content_core.processors.media.audio.get_audio_duration",
+                new_callable=AsyncMock,
+                return_value=1500.0,  # 25 minutes → 3 segments
+            ),
+            patch(
+                "content_core.processors.media.audio.extract_audio"
+            ) as mock_extract,
+        ):
+            mock_factory.create_speech_to_text.return_value = mock_stt_model
+
+            from content_core.processors.media.audio import transcribe_audio
+
+            await transcribe_audio("/fake/voice_note.opus", config)
+
+            output_paths = [call.args[1] for call in mock_extract.call_args_list]
+            assert len(output_paths) == 3
+            assert all(path.endswith(".opus") for path in output_paths)
+
 
 class TestGetAudioDuration:
     async def test_returns_duration_from_ffprobe(self):

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
     { name = "crawl4ai", marker = "extra == 'crawl4ai'", specifier = ">=0.7.0" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.86.0" },
-    { name = "esperanto", specifier = ">=2.20.1" },
+    { name = "esperanto", specifier = ">=2.26.0" },
     { name = "fast-ebook", specifier = ">=0.2.0" },
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "firecrawl-py", specifier = ">=4.13.0" },
@@ -1335,15 +1335,15 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.20.1"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/ae/7ff8cd45a2de81236722721417c06843abce3e2c3272edc2b6de1d800d08/esperanto-2.20.1.tar.gz", hash = "sha256:36707c5acdede3ea9c5de621f6dc4256d7e4b461b882cb63fff9e59b420e320c", size = 847075, upload-time = "2026-04-13T14:08:37.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/00/9f5197dfe620cc6e70bf31dc768a1d6cc5308d9f5b84cc66d0a7b35c448b/esperanto-2.26.0.tar.gz", hash = "sha256:21d33542b9c4805f41f7dd3c14bccc186b7b39dadd2489556719794b985facb3", size = 768871, upload-time = "2026-07-30T01:35:21.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/ca/17e01c763e73c168868614746d1d694a10246ece5901b426355cd2c5dd83/esperanto-2.20.1-py3-none-any.whl", hash = "sha256:2cd258b7f1db0d68c06a61effabd7431d23a1a0040a9f413823d1542c521d7ea", size = 204252, upload-time = "2026-04-13T14:08:36.328Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/2e/81c692d47fc5fbba46a3e3f2addd1e46e0b64ed7aabff469fbaf7e86f63a/esperanto-2.26.0-py3-none-any.whl", hash = "sha256:1337ab83c78a836f671ed10fcd649bb8286991ee4ee55c9ef2c40d436539e8bc", size = 262587, upload-time = "2026-07-30T01:35:19.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes Ogg/Opus audio extraction end to end, and raises the `esperanto` floor to pick up the STT `response_format` fix.

`.opus` files — the common export format for WhatsApp voice messages — raised `UnsupportedTypeException`. Two independent bugs were in the way; the second only becomes visible once the first is fixed, which is why they ship together.

## Part 1 — detection

`.opus` was missing from `_load_extension_mapping()`, and `_load_binary_signatures()` had no `OggS` entry at all, so neither detection path recognized the file. (Worth noting: `.ogg` worked *only* by extension, so content sniffing was never a fallback here.)

Adds `.opus` → `audio/ogg` plus an `OggS` signature. Since Ogg carries video too, the signature disambiguates by codec identification header — Opus/Vorbis/FLAC → `audio/ogg`, Theora → `video/ogg` — following the existing `RIFF` special-case pattern. Without that, an Ogg Theora file would be detected as audio and routed to the wrong pipeline.

No orchestrator change needed: `extraction.py:133` already routes on the generic `audio/` prefix.

## Part 2 — segment splitting

`transcribe_audio` splits audio over 10 minutes and named each segment `.mp3`, while `extract_audio` copies the stream without re-encoding. ffmpeg picks the muxer from the output extension, so this asked it to mux an Opus stream into an MP3 container:

```
[mp3 @ ...] Invalid audio stream. Exactly one MP3 audio stream is required.
Conversion failed!
```

This was never Opus-specific — it hit any source whose codec can't live in an MP3 container, including the already-supported `.flac` and `.ogg`, whenever the file exceeded 10 minutes. Segments now derive their extension from the source. The same hardcoded `.mp3` in `split_audio()` is fixed alongside it.

Preserving the container was chosen over re-encoding to MP3, which would contradict the stated "no re-encoding" intent of both helpers and cost time and quality on every long file.

## Dependency bump

`esperanto>=2.20.1` → `>=2.26.0`. Below that floor, every non-Whisper OpenAI and Azure transcription model fails before transcription starts, because `verbose_json` was requested for anything not matching a narrow `gpt-4o-*-transcribe` name shape. Reported upstream as lfnovo/esperanto#269, fixed in v2.26.0.

## Test plan

- `uv run pytest tests/unit tests/integration` → **297 passed**
- New unit tests: Opus detected by signature and by extension, Ogg/Vorbis unchanged, Theora routed as video, and split segments keeping the source extension
- Verified against a real `libopus` file, not just the synthetic fixtures: detection returns `audio/ogg`, `check_file_support` routes it to the `audio` processor, and a stream-copied segment comes back as a valid 4s Ogg per `ffprobe`
- Confirmed the installed `esperanto` is 2.26.0 and carries the shared `_resolve_transcription_response_format` helper

Closes #69
Closes #70


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

