### PR TITLE
test: drop stale title assertion from URL engine e2e tests

### DIFF
--- a/tests/e2e/test_url_engines.py
+++ b/tests/e2e/test_url_engines.py
@@ -20,7 +20,6 @@ async def test_extract_content_from_url():
     assert hasattr(result, "source_type")
     assert result.source_type == "url"
     assert "Supernova Labs" in result.title
-    assert "AI Consulting" in result.title
 
 
 @pytest.mark.asyncio
@@ -39,7 +38,6 @@ async def test_extract_content_from_url_firecrawl():
     assert hasattr(result, "source_type")
     assert result.source_type == "url"
     assert "Supernova Labs" in result.title
-    assert "AI Consulting" in result.title
     assert len(result.content) > 100
     assert "AI" in result.content
 


### PR DESCRIPTION
## Summary

`make test-e2e` was permanently red on two assertions that outlived the site they check.

`test_extract_content_from_url` (bs4) and `test_extract_content_from_url_firecrawl` both asserted `"AI Consulting" in result.title` against `supernovalabs.com`. That homepage now returns *"Supernova Labs | Principles that last. Not the tool of the month."* — both engines extract it correctly, so only the expectation was stale.

The `jina` and `crawl4ai` tests in the same file already assert just the stable `"Supernova Labs"` fragment. `7140a99` ("make e2e tests resilient to environment differences") made those resilient and left these two behind; this finishes that job.

## Note on assertion strength

I first replaced the removed line in the bs4 test with `len(result.content) > 100`, matching the sibling tests, and it failed at 65 chars: the `simple` engine returns only the title as content for this JS-heavy page, since readability finds no article body. That is a known limitation of the engine rather than something to pin here, so the bs4 test keeps its original shape minus the stale line.

## Test plan

- `make test-e2e` → **9 passed** (was 7 passed / 2 failed)
- Unaffected by `tests/unit` and `tests/integration`, which don't run under the `e2e` marker; the canonical validator stays green at 297 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

