### PR TITLE
chore: bump version to 2.0.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "content-core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
   "author": {
     "name": "Luis Novo",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "content-core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
   "skills": "./skills/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2026-07-30
+
 ### Added
-- Plugin marketplace support for Claude Code and Codex: the repository now carries `.claude-plugin/` (plugin + marketplace manifests) and `.codex-plugin/` + `.agents/plugins/` manifests, so the agent skill installs natively via `/plugin marketplace add lfnovo/content-core` (Claude Code) or via the Codex marketplace catalog
+- Plugin marketplace support for Claude Code and Codex (#63): the repository now carries `.claude-plugin/` (plugin + marketplace manifests) and `.codex-plugin/` + `.agents/plugins/` manifests, so the agent skill installs natively via `/plugin marketplace add lfnovo/content-core` (Claude Code) or via the Codex marketplace catalog
 
 ### Changed
-- Agent skill moved from the repository root (`SKILL.md`) to `skills/content-core/SKILL.md` and refreshed: Reddit capability documented, YouTube `live`/`shorts` URL forms, portable frontmatter, `--version`, updated model examples. The old raw-file URL no longer resolves — the README documents the new path and the marketplace install
-- Minimum `esperanto` version raised to 2.26.0, which fixes every non-Whisper OpenAI and Azure transcription model: `verbose_json` was requested for anything that didn't match a narrow `gpt-4o-*-transcribe` name shape, so `gpt-transcribe` and friends failed before transcription started
+- Agent skill moved from the repository root (`SKILL.md`) to `skills/content-core/SKILL.md` and refreshed (#63): Reddit capability documented, YouTube `live`/`shorts` URL forms, portable frontmatter, `--version`, updated model examples. The old raw-file URL no longer resolves — the README documents the new path and the marketplace install
+- Minimum `esperanto` version raised to 2.26.0 (#70), which fixes every non-Whisper OpenAI and Azure transcription model: `verbose_json` was requested for anything that didn't match a narrow `gpt-4o-*-transcribe` name shape, so `gpt-transcribe` and friends failed before transcription started
 
 ### Fixed
-- `.opus` files (the common export format for WhatsApp voice messages) raised `UnsupportedTypeException` instead of being transcribed — the extension was missing from the MIME mapping, and the Ogg container had no magic-byte signature at all. Ogg files are now detected by content as well as extension, with Opus/Vorbis/FLAC routed to audio and Theora to video
-- Audio longer than 10 minutes failed for any non-MP3 source, including the already-supported `.flac` and `.ogg`: segments were stream-copied but named `.mp3`, so ffmpeg refused to mux them. Segments now keep the source container
+- `.opus` files (the common export format for WhatsApp voice messages) raised `UnsupportedTypeException` instead of being transcribed (#69) — the extension was missing from the MIME mapping, and the Ogg container had no magic-byte signature at all. Ogg files are now detected by content as well as extension, with Opus/Vorbis/FLAC routed to audio and Theora to video
+- Audio longer than 10 minutes failed for any non-MP3 source, including the already-supported `.flac` and `.ogg` (#69): segments were stream-copied but named `.mp3`, so ffmpeg refused to mux them. Segments now keep the source container
 
 ## [2.0.4] - 2026-07-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-core"
-version = "2.0.4"
+version = "2.0.5"
 description = "Extract what matters from any media source. Available as Python Library, macOS Service, CLI and MCP Server"
 readme = "README.md"
 homepage = "https://github.com/lfnovo/content-core"

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "content-core"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

Cuts **2.0.5**, a patch release. Nothing in the consumer surfaces changed — no public exports, CLI flags, MCP tool signatures or config keys were touched this cycle — so the aggregate diff is bug fixes plus a raised dependency floor.

## What ships

**Fixed**
- `.opus` files raised `UnsupportedTypeException` instead of being transcribed (#69). Relevant for WhatsApp voice messages, which export as `.opus`
- Audio over 10 minutes failed for any non-MP3 source, `.flac` and `.ogg` included (#69): segments were stream-copied into `.mp3`, which ffmpeg refuses to mux

**Changed**
- `esperanto` floor raised to 2.26.0 (#70) — below it, every non-Whisper OpenAI and Azure transcription model fails before transcription starts
- Agent skill relocated and refreshed (#63)

**Added**
- Plugin marketplace support for Claude Code and Codex (#63)

## Release checklist

- `pyproject.toml`, `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` all at 2.0.5 (`marketplace.json` stays at 1.0.0 — it versions the catalog, not the package)
- `uv.lock` refreshed and committed
- CHANGELOG `[Unreleased]` dated as `[2.0.5] - 2026-07-30`, fresh empty `[Unreleased]` opened above it, and the missing `(#NN)` references backfilled on the entries that lacked them

## Test plan

- Canonical validator on this commit: `uv run pytest tests/unit tests/integration` → **297 passed**
- Packaging gate on the pre-bump commit, all three consumer surfaces green: wheel asset inspection, bare install import, public API import, `content-core --help` plus real text and PDF extraction, MCP JSON-RPC handshake, and `docling`/`crawl4ai`/`langchain` extras resolving. It re-runs on this exact commit before the tag is pushed
- `make test-e2e` → **9 passed** with real API keys, covering media/STT (the area that changed this cycle) plus URL engines, YouTube and remote PDF as baseline
- `make test-e2e-heavy` not run — Docling was untouched this cycle, so it is recorded as unverified this release

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

