### PR TITLE
fix: present Ogg audio to STT providers under an accepted extension

### DIFF
--- a/src/content_core/processors/media/audio.py
+++ b/src/content_core/processors/media/audio.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import math
 import os
+import shutil
 import subprocess
 import tempfile
 import traceback
@@ -11,6 +12,35 @@ from content_core.common.retry import retry_audio_transcription
 from content_core.config import ContentCoreConfig
 from content_core.logging import logger
 from content_core.common.state import ExtractionOutput
+
+# STT providers validate uploads by filename extension, not by content. OpenAI
+# accepts 'ogg' and 'oga' but rejects 'opus' outright, even though `.opus` *is*
+# Opus-in-Ogg and the bytes are identical — verified with the same file under
+# both names, holding the multipart Content-Type constant. Present such files
+# under an accepted extension; the user's own file is never renamed.
+UPLOAD_EXTENSION_ALIASES = {".opus": ".ogg"}
+
+
+def upload_extension(path: str) -> str:
+    """Return the extension a provider will accept for this file."""
+    ext = os.path.splitext(path)[1].lower()
+    return UPLOAD_EXTENSION_ALIASES.get(ext, ext)
+
+
+def _aliased_upload_path(file_path: str, temp_dir: str) -> str:
+    """Expose `file_path` under a provider-accepted extension, without copying.
+
+    Falls back to a real copy where symlinks are unavailable.
+    """
+    alias = os.path.join(
+        temp_dir, f"{os.path.splitext(os.path.basename(file_path))[0]}{upload_extension(file_path)}"
+    )
+    source = os.path.abspath(file_path)
+    try:
+        os.symlink(source, alias)
+    except (OSError, NotImplementedError):
+        shutil.copy2(source, alias)
+    return alias
 
 
 async def get_audio_duration(input_file: str) -> float:
@@ -152,7 +182,9 @@ async def transcribe_audio(file_path: str, config: ContentCoreConfig) -> Extract
 
             # Segments are stream-copied, so they must keep the source container:
             # muxing e.g. an Opus stream into a .mp3 output makes ffmpeg fail.
-            source_ext = os.path.splitext(file_path)[1] or ".mp3"
+            # The alias only renames within the same container (.opus -> .ogg),
+            # so stream copy stays valid while the upload becomes acceptable.
+            source_ext = upload_extension(file_path) or ".mp3"
 
             if duration_s > segment_length_s:
                 logger.info(
@@ -169,6 +201,9 @@ async def transcribe_audio(file_path: str, config: ContentCoreConfig) -> Extract
                         None, partial(extract_audio, file_path, output_path, start_time, end_time)
                     )
                     output_files.append(output_path)
+            elif source_ext != os.path.splitext(file_path)[1].lower():
+                # Short file sent as-is, so it needs the alias to be accepted.
+                output_files = [_aliased_upload_path(file_path, temp_dir)]
             else:
                 output_files = [file_path]
 

--- a/tests/unit/test_media_pipeline.py
+++ b/tests/unit/test_media_pipeline.py
@@ -1,6 +1,8 @@
 """Unit tests for content_core.processors.media (audio + video)."""
 
 import json
+import os
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -189,7 +191,83 @@ class TestTranscribeAudio:
 
             output_paths = [call.args[1] for call in mock_extract.call_args_list]
             assert len(output_paths) == 3
-            assert all(path.endswith(".opus") for path in output_paths)
+            # .ogg, not .opus: same container, but OpenAI rejects the `.opus`
+            # extension on upload. Stream copy stays valid across the alias.
+            assert all(path.endswith(".ogg") for path in output_paths)
+
+    async def test_short_opus_is_uploaded_under_accepted_extension(self):
+        """A short .opus is sent as-is, so it needs an accepted name.
+
+        OpenAI validates the upload by filename extension and rejects `opus`,
+        even though the bytes are Opus-in-Ogg and `.ogg` is accepted.
+        """
+        config = ContentCoreConfig(
+            stt_provider="openai",
+            stt_model="whisper-1",
+            audio_provider="openai",
+            audio_model=None,
+        )
+
+        mock_stt_model = MagicMock()
+        mock_result = MagicMock()
+        mock_result.text = "voice note"
+        mock_stt_model.atranscribe = AsyncMock(return_value=mock_result)
+
+        with tempfile.TemporaryDirectory() as source_dir:
+            source = os.path.join(source_dir, "voice_note.opus")
+            with open(source, "wb") as f:
+                f.write(b"OggS" + b"\x00" * 32)
+
+            with (
+                patch("esperanto.AIFactory") as mock_factory,
+                patch(
+                    "content_core.processors.media.audio.get_audio_duration",
+                    new_callable=AsyncMock,
+                    return_value=120.0,  # under the split threshold
+                ),
+            ):
+                mock_factory.create_speech_to_text.return_value = mock_stt_model
+
+                from content_core.processors.media.audio import transcribe_audio
+
+                result = await transcribe_audio(source, config)
+
+            assert result.content == "voice note"
+            uploaded = mock_stt_model.atranscribe.call_args.args[0]
+            assert uploaded.endswith(".ogg")
+            # The user's own file must be left exactly as it was
+            assert os.path.exists(source)
+            assert uploaded != source
+
+    async def test_mp3_is_uploaded_untouched(self):
+        """Formats providers already accept are passed through unchanged."""
+        config = ContentCoreConfig(
+            stt_provider="openai",
+            stt_model="whisper-1",
+            audio_provider="openai",
+            audio_model=None,
+        )
+
+        mock_stt_model = MagicMock()
+        mock_result = MagicMock()
+        mock_result.text = "clip"
+        mock_stt_model.atranscribe = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("esperanto.AIFactory") as mock_factory,
+            patch(
+                "content_core.processors.media.audio.get_audio_duration",
+                new_callable=AsyncMock,
+                return_value=120.0,
+            ),
+        ):
+            mock_factory.create_speech_to_text.return_value = mock_stt_model
+
+            from content_core.processors.media.audio import transcribe_audio
+
+            await transcribe_audio("/fake/clip.mp3", config)
+
+        assert mock_stt_model.atranscribe.call_args.args[0] == "/fake/clip.mp3"
 
 
 class TestGetAudioDuration:


### PR DESCRIPTION
## Summary

`.opus` still failed on v2.0.5 — one step later in the pipeline than before, as reported in #69.

Detection and segment containers were fixed in 2.0.5, so the file now reaches the provider. OpenAI then rejects it:

```
RuntimeError: OpenAI API error: Unsupported file format opus
```

Its accepted extensions for `/v1/audio/transcriptions` are `flac, m4a, mp3, mp4, mpeg, mpga, oga, ogg, wav, webm`. Ogg is there; `opus` is not.

## Why it is the filename, not the content

Holding the multipart `Content-Type` constant at `audio/ogg` and varying only the filename, with the same bytes:

| Upload | Result |
|---|---|
| `filename=x.opus`, `type=audio/ogg` | `Invalid file format. Supported formats: [... 'oga', 'ogg', ...]` |
| `filename=x.ogg`, `type=audio/ogg` | `{"text": "..."}` |

So the container is fine, the codec is fine, and the MIME type is fine. Only the name is rejected. This also rules out the MIME-guessing path as the culprit — that field is not what the provider consults.

## Fix

`.opus` is Opus-in-Ogg, so `.ogg` is not a disguise, it is the container's own name — the same equivalence the issue's own workaround relies on (`ffmpeg -c copy` to `.ogg`). Ogg-family input is now presented to the provider under an accepted extension:

- **Short files**, sent as-is, are exposed through a symlink in the existing temp dir. The user's file is never renamed, copied or touched, and a real copy is the fallback where symlinks are unavailable.
- **Segments** derive their extension from the alias. Renaming stays inside the same container, so the stream copy from 2.0.5 remains valid.

Formats providers already accept pass through unchanged.

## Scope note

The upload filename is built downstream in esperanto, which forwards whatever path it is given without validating. Mapping it there would fix this for every esperanto consumer, and that was raised with them; they prefer to keep the provider layer as-is, so the mapping lives here. This is a small, self-contained table — if it moves upstream later, this can be dropped.

## Test plan

- `uv run pytest tests/unit tests/integration` → **299 passed**
- New unit tests: short `.opus` uploaded under an accepted extension with the source file left intact, segments named `.ogg`, and `.mp3` passed through untouched
- Verified end to end against the real OpenAI API, both paths that were broken:
  - 5s `.opus` → accepted, 1 segment, source file intact
  - 700s `.opus` → accepted, split into 2 segments
  - the reporter's exact configuration, `stt_model = "gpt-transcribe"` with `.opus`, which was a double failure before → works

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

