### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "content-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
   "author": {
     "name": "Luis Novo",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "content-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Extract text content from URLs, documents, YouTube videos, Reddit posts, and audio/video files — via CLI (uvx) or MCP.",
   "skills": "./skills/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2026-07-30
+
+### Fixed
+- `.opus` audio still failed on 2.0.5, one step later in the pipeline (#69): OpenAI validates transcription uploads by filename extension and rejects `opus` while accepting `ogg`/`oga`, even though `.opus` is Opus-in-Ogg and the bytes are identical. Confirmed by varying only the filename with the `Content-Type` held constant. Ogg-family audio is now presented to the provider under an accepted extension — via a symlink for unsplit files, so the user's own file is never renamed or copied
+
 ## [2.0.5] - 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-core"
-version = "2.0.5"
+version = "2.0.6"
 description = "Extract what matters from any media source. Available as Python Library, macOS Service, CLI and MCP Server"
 readme = "README.md"
 homepage = "https://github.com/lfnovo/content-core"

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "content-core"
-version = "2.0.5"
+version = "2.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

Cuts **2.0.6**, a single-fix patch release that finishes what 2.0.5 started.

2.0.5 claimed `.opus` support and delivered it only partway: detection and segment containers were fixed, but the file was then rejected at upload because OpenAI validates transcription uploads by filename extension and does not accept `opus`. Anyone extracting a WhatsApp voice message with the default provider still saw a hard failure — with an error that reads like an API problem.

Ships #76, which presents Ogg-family audio to the provider under an accepted extension.

## Why patch

Bug fix only. No public exports, CLI flags, MCP tool signatures or config keys changed.

## Release checklist

- `pyproject.toml`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` all at 2.0.6 (`marketplace.json` stays at 1.0.0 — it versions the catalog)
- Manifests edited in place rather than reserialized, so the diff is one line each
- `uv.lock` refreshed and committed
- CHANGELOG `[2.0.6] - 2026-07-30` section added with the `(#69)` reference, fresh empty `[Unreleased]` kept above it

## Test plan

- Canonical validator: `uv run pytest tests/unit tests/integration` → **299 passed**
- `make test-e2e` → **9 passed** with real API keys, and the working tree is clean afterwards
- The fix itself was verified against the live OpenAI API on both previously broken paths (5s and 700s `.opus`, the latter exercising segmentation) plus the reporter's exact `gpt-transcribe` configuration — details in #76
- Packaging gate re-runs on the merged release commit before the tag is pushed
- `make test-e2e-heavy` not run — Docling untouched, recorded as unverified this release

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

