### PR TITLE
Add CRW as a URL extraction engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,16 @@ Content Core uses `ContentCoreConfig` powered by pydantic-settings. Settings are
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CCORE_URL_ENGINE` | URL extraction engine (`auto`, `simple`, `firecrawl`, `jina`, `crawl4ai`) | `auto` |
+| `CCORE_URL_ENGINE` | URL extraction engine (`auto`, `simple`, `firecrawl`, `crw`, `jina`, `crawl4ai`) | `auto` |
 | `CCORE_DOCUMENT_ENGINE` | Document extraction engine (`auto`, `simple`, `docling`) | `auto` |
 | `CCORE_AUDIO_CONCURRENCY` | Concurrent audio transcriptions (1-10) | `3` |
 | `CRAWL4AI_API_URL` | Crawl4AI Docker API URL (omit for local browser mode) | - |
 | `FIRECRAWL_API_URL` | Custom Firecrawl API URL for self-hosted instances | - |
 | `CCORE_FIRECRAWL_PROXY` | Firecrawl proxy mode (`auto`, `basic`, `stealth`) | `auto` |
 | `CCORE_FIRECRAWL_WAIT_FOR` | Wait time in ms before extraction | `3000` |
+| `CRW_API_URL` | Custom CRW API URL for self-hosted instances | `https://api.fastcrw.com` |
+| `CCORE_CRW_RENDER_JS` | CRW: force the JS renderer instead of auto-escalation | `false` |
+| `CCORE_CRW_WAIT_FOR` | CRW wait time in ms before extraction | `0` |
 | `CCORE_LLM_PROVIDER` | LLM provider for summarization | - |
 | `CCORE_LLM_MODEL` | LLM model for summarization | - |
 | `CCORE_STT_PROVIDER` | Speech-to-text provider | - |
@@ -237,7 +240,7 @@ Content Core uses `ContentCoreConfig` powered by pydantic-settings. Settings are
 | `CCORE_STT_TIMEOUT` | Speech-to-text timeout in seconds | - |
 | `CCORE_YOUTUBE_LANGUAGES` | Preferred YouTube transcript languages | - |
 
-API keys for external services are set via their standard environment variables (e.g., `OPENAI_API_KEY`, `FIRECRAWL_API_KEY`, `JINA_API_KEY`).
+API keys for external services are set via their standard environment variables (e.g., `OPENAI_API_KEY`, `FIRECRAWL_API_KEY`, `CRW_API_KEY`, `JINA_API_KEY`).
 
 ### Proxy Configuration
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -170,7 +170,7 @@ content-core config delete llm_provider
 | `stt_provider` | Speech-to-text provider | `openai` |
 | `stt_timeout` | STT API timeout in seconds | `3600` |
 | `summary_model` | Override LLM model for summarization | — |
-| `url_engine` | URL extraction engine (`auto`, `simple`, `firecrawl`, `jina`, `crawl4ai`) | `auto` |
+| `url_engine` | URL extraction engine (`auto`, `simple`, `firecrawl`, `crw`, `jina`, `crawl4ai`) | `auto` |
 | `youtube_languages` | Transcript languages, comma-separated | `en,es,pt` |
 
 Run `content-core config --help` to see this list in the terminal.
@@ -222,7 +222,7 @@ export OPENAI_API_KEY=sk-...
 ### Engine flag
 
 The `--engine` flag is routed automatically based on input type:
-- **URLs** → overrides `url_engine` (options: `firecrawl`, `jina`, `crawl4ai`, `simple`)
+- **URLs** → overrides `url_engine` (options: `firecrawl`, `crw`, `jina`, `crawl4ai`, `simple`)
 - **Files** → overrides `document_engine` (options: `docling`, `simple`)
 
 See [Usage documentation](usage.md) for all configuration options.

--- a/src/content_core/cli.py
+++ b/src/content_core/cli.py
@@ -34,7 +34,7 @@ def cli(debug):
 @click.option(
     "--engine",
     default=None,
-    help="Override extraction engine (URL: firecrawl, jina, crawl4ai, simple; Document: docling, simple)",
+    help="Override extraction engine (URL: firecrawl, crw, jina, crawl4ai, simple; Document: docling, simple)",
 )
 @click.option("--formulas", is_flag=True, default=False, help="Enable formula extraction (Docling only)")
 @click.option("--pictures", is_flag=True, default=False, help="Enable image description + chart extraction (Docling only)")
@@ -106,6 +106,9 @@ def config():
       audio_provider       Override STT provider
       docling_output_format  Docling output format (default: markdown)
       document_engine      Document extraction engine (auto, simple, docling)
+      crw_api_url          CRW API URL (default: https://api.fastcrw.com)
+      crw_render_js        CRW: force the JS renderer (default: false)
+      crw_wait_for         CRW wait time in ms before extraction (default: 0)
       firecrawl_api_url    Firecrawl API URL
       firecrawl_proxy      Firecrawl proxy mode: auto, basic, stealth (default: auto)
       firecrawl_wait_for   Firecrawl wait time in ms before extraction (default: 3000)
@@ -115,7 +118,7 @@ def config():
       stt_provider         Speech-to-text provider (default: openai)
       stt_timeout          STT API timeout in seconds (default: 3600)
       summary_model        Override LLM model for summarization
-      url_engine           URL extraction engine (auto, simple, firecrawl, jina, crawl4ai)
+      url_engine           URL extraction engine (auto, simple, firecrawl, crw, jina, crawl4ai)
       youtube_languages    Transcript languages, comma-separated (default: en,es,pt)
       docling_formulas     Enable formula extraction (default: false)
       docling_ocr          Enable OCR for scanned PDFs (default: true)
@@ -206,7 +209,7 @@ def _build_config(inp, engine, formulas=False, pictures=False, no_ocr=False):
 
     from content_core.config import ContentCoreConfig
 
-    VALID_URL_ENGINES = {"auto", "simple", "firecrawl", "jina", "crawl4ai"}
+    VALID_URL_ENGINES = {"auto", "simple", "firecrawl", "crw", "jina", "crawl4ai"}
     VALID_DOC_ENGINES = {"auto", "simple", "docling"}
 
     kwargs = {**docling_overrides}

--- a/src/content_core/common/types.py
+++ b/src/content_core/common/types.py
@@ -10,6 +10,7 @@ UrlEngine = Literal[
     "auto",
     "simple",
     "firecrawl",
+    "crw",
     "jina",
     "crawl4ai",
 ]

--- a/src/content_core/config.py
+++ b/src/content_core/config.py
@@ -64,6 +64,11 @@ class ContentCoreConfig(BaseSettings):
     # Crawl4AI
     crawl4ai_api_url: Optional[str] = None
 
+    # CRW
+    crw_api_url: str = "https://api.fastcrw.com"
+    crw_render_js: bool = False
+    crw_wait_for: int = 0
+
     # Firecrawl
     firecrawl_api_url: str = "https://api.firecrawl.dev"
     firecrawl_proxy: Optional[str] = "auto"
@@ -202,6 +207,7 @@ def config_list() -> dict:
 # ---------------------------------------------------------------------------
 
 DEFAULT_FIRECRAWL_API_URL = "https://api.firecrawl.dev"
+DEFAULT_CRW_API_URL = "https://api.fastcrw.com"
 
 
 def get_crawl4ai_api_url() -> str | None:
@@ -214,6 +220,18 @@ def get_crawl4ai_api_url() -> str | None:
     if env_url:
         return env_url
     return get_default_config().crawl4ai_api_url
+
+
+def get_crw_api_url() -> str:
+    """Return CRW API URL.
+
+    Checks CRW_API_URL env var first (standard CRW convention, matching
+    CRW_API_KEY), then falls back to config file / default.
+    """
+    env_url = os.environ.get("CRW_API_URL")
+    if env_url:
+        return env_url
+    return get_default_config().crw_api_url
 
 
 def get_firecrawl_api_url() -> str:

--- a/src/content_core/mcp/server.py
+++ b/src/content_core/mcp/server.py
@@ -25,7 +25,7 @@ async def extract_content(
     Args:
         url: URL to extract content from (web page, YouTube video, PDF link, etc.)
         file_path: Local file path to extract content from
-        engine: Optional extraction engine override (firecrawl, jina, crawl4ai, simple, docling)
+        engine: Optional extraction engine override (firecrawl, crw, jina, crawl4ai, simple, docling)
         formulas: Enable formula extraction via Docling (requires engine=docling)
         pictures: Enable image description + chart data extraction via Docling (requires engine=docling)
         no_ocr: Disable OCR in Docling (requires engine=docling)

--- a/src/content_core/processors/url/__init__.py
+++ b/src/content_core/processors/url/__init__.py
@@ -18,6 +18,7 @@ from content_core.processors.url.firecrawl import (
     _fetch_url_firecrawl,
     extract_url_firecrawl,
 )
+from content_core.processors.url.crw import _fetch_url_crw, extract_url_crw
 from content_core.processors.url.crawl4ai import extract_url_crawl4ai
 
 
@@ -83,6 +84,8 @@ async def _extract_url_with_engine(url: str, engine: str, config: ContentCoreCon
         return await extract_url_bs4(url)
     elif engine == "firecrawl":
         return await extract_url_firecrawl(url, config)
+    elif engine == "crw":
+        return await extract_url_crw(url, config)
     elif engine == "jina":
         return await extract_url_jina(url)
     elif engine == "crawl4ai":
@@ -135,9 +138,11 @@ __all__ = [
     "_fetch_url_html",
     "_fetch_url_jina",
     "_fetch_url_firecrawl",
+    "_fetch_url_crw",
     "extract_url_bs4",
     "extract_url_jina",
     "extract_url_firecrawl",
+    "extract_url_crw",
     "extract_url_crawl4ai",
     "detect_remote_mime",
     "_extract_url_with_engine",

--- a/src/content_core/processors/url/crw.py
+++ b/src/content_core/processors/url/crw.py
@@ -1,0 +1,60 @@
+import os
+
+import aiohttp
+
+from content_core.common.retry import retry_url_api
+from content_core.config import (
+    ContentCoreConfig,
+    DEFAULT_CRW_API_URL,
+    get_default_config,
+)
+from content_core.logging import logger
+
+
+@retry_url_api()
+async def _fetch_url_crw(url: str, config: ContentCoreConfig) -> dict:
+    """Internal function to fetch URL content via CRW - wrapped with retry logic."""
+    api_url = os.environ.get("CRW_API_URL") or config.crw_api_url
+    if api_url != DEFAULT_CRW_API_URL:
+        logger.debug(f"Using custom CRW API URL: {api_url}")
+
+    payload: dict = {"url": url, "formats": ["markdown"], "onlyMainContent": True}
+    if config.crw_render_js:
+        payload["renderJs"] = True
+    if config.crw_wait_for > 0:
+        payload["waitFor"] = config.crw_wait_for
+
+    headers = {"Content-Type": "application/json"}
+    api_key = os.environ.get("CRW_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    async with aiohttp.ClientSession(trust_env=True) as session:
+        async with session.post(
+            f"{api_url.rstrip('/')}/v1/scrape",
+            json=payload,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=120),
+        ) as response:
+            response.raise_for_status()
+            body = await response.json()
+
+    data = body.get("data") or {}
+    return {
+        "title": (data.get("metadata") or {}).get("title", ""),
+        "content": data.get("markdown", ""),
+    }
+
+
+async def extract_url_crw(url: str, config: ContentCoreConfig | None = None) -> dict | None:
+    """
+    Get the content of a URL using CRW.
+    Returns {"title": ..., "content": ...} or None on failure.
+    Includes retry logic for transient API failures.
+    """
+    cfg = config or get_default_config()
+    try:
+        return await _fetch_url_crw(url, cfg)
+    except Exception as e:
+        logger.error(f"CRW extraction failed for {url} after retries: {e}")
+        return None

--- a/tests/unit/test_url_engine_select.py
+++ b/tests/unit/test_url_engine_select.py
@@ -97,6 +97,23 @@ async def test_simple_engine():
 # ---------------------------------------------------------------------------
 # 5. jina engine -> uses jina directly
 # ---------------------------------------------------------------------------
+# crw engine
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_crw_engine():
+    cfg = ContentCoreConfig(url_engine="crw")
+    with patch(
+        "content_core.processors.url.extract_url_crw",
+        new_callable=AsyncMock,
+        return_value={"title": "CRW", "content": "CRW Content"},
+    ) as mock_crw:
+        result = await extract_from_url("https://example.com", cfg)
+        mock_crw.assert_awaited_once_with("https://example.com", cfg)
+        assert result.content == "CRW Content"
+        assert result.title == "CRW"
+
+
+# ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_jina_engine():
     cfg = ContentCoreConfig(url_engine="jina")


### PR DESCRIPTION
adds `crw` as a url_engine option next to firecrawl, jina and crawl4ai.

why it might be worth having: CRW is a single self-contained binary under AGPL-3.0, so unlike the hosted options it can run entirely on the user's own machine, and unlike crawl4ai it does not pull in a browser stack. for content-core that means one more extraction path that works offline.

what changed:
- new `processors/url/crw.py`, same shape as the firecrawl processor (retry wrapper, returns `{title, content}`, returns None on failure)
- `crw` added to the `UrlEngine` literal, the CLI's valid-engine set, and the MCP engine docstring
- config gets `crw_api_url` / `crw_render_js` / `crw_wait_for`, plus a `get_crw_api_url()` helper matching `get_firecrawl_api_url()`
- env table and CLI docs updated

deliberately conservative:
- **no new dependency.** the processor posts to `/v1/scrape` with aiohttp, which is already a core dep, rather than adding the CRW SDK
- **the `auto` chain is untouched.** crw only runs when someone asks for it, so no existing behaviour changes. happy to wire it into `auto` if you'd prefer, but that felt like your call rather than mine

testing:
- added `test_crw_engine` to `tests/unit/test_url_engine_select.py`, following the existing firecrawl test
- full unit suite passes: 278 passed
- also ran it for real against a live endpoint: `url_engine='crw'` on the RAG wikipedia article returned the correct title and 16,548 chars of markdown

self-hosters can point `CRW_API_URL` at their own instance; the hosted default only applies if they set `CRW_API_KEY`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/content-core/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

